### PR TITLE
Add review mode to revisit incorrect answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
     <label><input type="checkbox" id="keepOrder"> Keep Order</label>
     <button id="darkBtn">Dark</button>
     <button id="resetBtn">Reset</button>
+    <button id="reviewBtn">Review Incorrect</button>
     <input id="search" placeholder="Search..."/>
   </div>
   <div id="container">
@@ -251,6 +252,7 @@
     if(!state.bookmarks) state.bookmarks={};
     if(!state.settings) state.settings={dark:false, showHints:false, shuffleQuestions:false, shuffleChoices:false};
     if(!state.sets) state.sets={};
+    if(!state.incorrect) state.incorrect={};
     AppStorage.save(state);
 
     function getQuestions(){return state.questions;}
@@ -263,8 +265,14 @@
     function updateSettings(s){ state.settings=Object.assign(state.settings,s); AppStorage.save(state); }
     function saveSet(name,ids){ state.sets[name]=ids; AppStorage.save(state); }
     function getSets(){ return state.sets; }
+    function markQuestion(id,isCorrect){
+      if(isCorrect) delete state.incorrect[id];
+      else state.incorrect[id]=true;
+      AppStorage.save(state);
+    }
+    function getIncorrect(){ return state.incorrect; }
     function reset(){ localStorage.removeItem(AppStorage.KEY); location.reload(); }
-    window.Data={getQuestions,setQuestions,addQuestions,toggleBookmark,isBookmarked,saveResult,getSettings,updateSettings,saveSet,getSets,reset,state};
+    window.Data={getQuestions,setQuestions,addQuestions,toggleBookmark,isBookmarked,saveResult,getSettings,updateSettings,saveSet,getSets,markQuestion,getIncorrect,reset,state};
   })();
 
   (()=>{ // Parsing Module
@@ -319,6 +327,7 @@
     const timerEl=document.getElementById('timer');
     const hintBtn=document.getElementById('hintBtn');
     const hintEl=document.getElementById('hint');
+    const reviewBtn=document.getElementById('reviewBtn');
     let questions=[]; let index=0; let correct=0; let startTime=0; let timerInterval=null; let mode='practice'; let answered=false; let order=[];
 
     function loadSession(){
@@ -329,6 +338,7 @@
       applyFilters();
       renderSets();
       renderQuestion();
+      updateReviewBtn();
       document.body.classList.toggle('dark',settings.dark);
       document.getElementById('shuffleChoices').checked=settings.shuffleChoices;
       document.getElementById('keepOrder').checked=!settings.shuffleQuestions;
@@ -343,6 +353,7 @@
         if(tagFilter.length && !tagFilter.every(t=>q.tags.includes(t))) return false;
         if(diff && q.difficulty!==diff) return false;
         if(search && !q.question.toLowerCase().includes(search)) return false;
+        if(mode==='review' && !Data.getIncorrect()[q.id]) return false;
         return true;
       });
       if(document.getElementById('keepOrder').checked){} else if(document.getElementById('shuffleBtn').dataset.active==='1'||Data.getSettings().shuffleQuestions) questions=shuffleArray([...questions]);
@@ -380,7 +391,8 @@
       if(!sel){alert('Select an option');return;}
       const q=questions[index];
       answered=true;
-      if(parseInt(sel.value)===q.answerIndex){
+      const isCorrect=parseInt(sel.value)===q.answerIndex;
+      if(isCorrect){
         feedbackEl.textContent='Correct! '+(q.explanation||'');
         feedbackEl.className='correct';
         correct++;}
@@ -388,6 +400,9 @@
         feedbackEl.textContent='Incorrect. '+(q.explanation||'');
         feedbackEl.className='incorrect';
       }
+      Data.markQuestion(q.id,isCorrect);
+      if(mode==='review' && isCorrect){questions.splice(index,1);index--;}
+      updateReviewBtn();
       document.getElementById('confirmBtn').classList.add('hidden');
       document.getElementById('nextBtn').classList.remove('hidden');
       progressBar.style.width=((index+1)/questions.length*100)+'%';
@@ -428,6 +443,7 @@
     document.getElementById('tagFilter').addEventListener('change',()=>{applyFilters();renderQuestion();});
     document.getElementById('search').addEventListener('input',()=>{applyFilters();renderQuestion();});
     document.getElementById('resetBtn').addEventListener('click',()=>{if(confirm('Reset everything?')) Data.reset();});
+    reviewBtn.addEventListener('click',()=>{if(reviewBtn.disabled) return;mode='review';document.getElementById('modeSelect').value='review';stopTimer();applyFilters();renderQuestion();});
 
     hintBtn.addEventListener('click',()=>hintEl.classList.toggle('hidden'));
 
@@ -437,11 +453,11 @@
       if(e.key==='Enter'){ answered?next():confirm(); }
       if(e.key==='b'||e.key==='B') document.getElementById('bookmarkBtn').click();
       if(e.key==='s'||e.key==='S'){document.getElementById('shuffleBtn').click();}
-      if(e.key==='r'||e.key==='R'){document.getElementById('modeSelect').value='review';mode='review';applyFilters();renderQuestion();}
-      if(e.key==='e'||e.key==='E'){document.getElementById('modeSelect').value='exam';mode='exam';}
+      if(e.key==='r'||e.key==='R'){document.getElementById('modeSelect').value='review';mode='review';stopTimer();applyFilters();renderQuestion();}
+      if(e.key==='e'||e.key==='E'){document.getElementById('modeSelect').value='exam';mode='exam';applyFilters();renderQuestion();startTimer();}
     });
 
-    document.getElementById('modeSelect').addEventListener('change',e=>{mode=e.target.value;index=0;correct=0;renderQuestion();if(mode==='exam'){startTimer();}else{stopTimer();}});
+    document.getElementById('modeSelect').addEventListener('change',e=>{mode=e.target.value;index=0;correct=0;applyFilters();renderQuestion();if(mode==='exam'){startTimer();}else{stopTimer();}updateReviewBtn();});
 
     function startTimer(){startTime=Date.now();timerEl.classList.remove('hidden');timerInterval=setInterval(()=>{const s=Math.floor((Date.now()-startTime)/1000);timerEl.textContent=('0'+Math.floor(s/60)).slice(-2)+':'+('0'+(s%60)).slice(-2);},1000);}
     function stopTimer(){timerEl.classList.add('hidden');clearInterval(timerInterval);}
@@ -479,6 +495,12 @@
       ul.innerHTML='';
       const sets=Data.getSets();
       Object.keys(sets).forEach(k=>{const li=document.createElement('li');const btn=document.createElement('button');btn.textContent=k;btn.onclick=()=>{questions=Data.getQuestions().filter(q=>sets[k].includes(q.id));index=0;correct=0;renderQuestion();};li.appendChild(btn);ul.appendChild(li);});
+    }
+
+    function updateReviewBtn(){
+      const count=Object.keys(Data.getIncorrect()).length;
+      reviewBtn.disabled=count===0;
+      reviewBtn.textContent='Review Incorrect ('+count+')';
     }
 
     window.addEventListener('load',loadSession);


### PR DESCRIPTION
## Summary
- track incorrect responses in localStorage
- filter questions in review mode based on incorrect history
- update keyboard and mode controls for timer and filtering
- add Review Incorrect button to UI and toggle availability based on mistakes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19bf06ffc832c98c5675b9b561ee0