### PR TITLE
Add start and test scripts for webapp

### DIFF
--- a/mcqproject/package.json
+++ b/mcqproject/package.json
@@ -4,9 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "npm run dev",
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/mcqproject/test/questions.test.js
+++ b/mcqproject/test/questions.test.js
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import questions from '../src/questions.js';
+
+test('questions array has expected length', () => {
+  assert.ok(Array.isArray(questions));
+  assert.strictEqual(questions.length, 3);
+});


### PR DESCRIPTION
## Summary
- add npm start script to run Vite dev server
- add node-based test script with example question test

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm start` (terminated after launch)


------
https://chatgpt.com/codex/tasks/task_e_68c1db2bbbcc832ca0b28ae1d58297a2