### PR TITLE
Add standalone SC-200 CSV practice web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,507 +1,288 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <title>MCQ Practice App</title>
-  <style>
-    :root {
-      --bg: #fff;
-      --fg: #000;
-      --accent: #0077cc;
-      --error: #cc0000;
-      --correct: #0a0;
-    }
-    body.dark {
-      --bg: #1e1e1e;
-      --fg: #f0f0f0;
-      --accent: #4aa3ff;
-      --error: #ff5555;
-      --correct: #44dd44;
-    }
-    body {
-      background: var(--bg);
-      color: var(--fg);
-      font-family: Arial, sans-serif;
-      margin: 0;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
-    }
-    #topbar {
-      background: var(--accent);
-      color: #fff;
-      padding: 0.5rem;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      align-items: center;
-    }
-    #topbar button,
-    #topbar select,
-    #topbar input {
-      margin-right: 0.5rem;
-    }
-    #container {
-      flex: 1;
-      display: flex;
-      overflow: hidden;
-    }
-    main {
-      flex: 2;
-      padding: 1rem;
-      overflow-y: auto;
-    }
-    aside {
-      flex: 1;
-      border-left: 1px solid #ccc;
-      padding: 1rem;
-      overflow-y: auto;
-    }
-    @media (max-width: 700px) {
-      #container {
-        flex-direction: column;
-      }
-      aside {
-        border-left: none;
-        border-top: 1px solid #ccc;
-      }
-    }
-    .choices li {
-      list-style: none;
-      margin: 0.5rem 0;
-    }
-    .choices label {
-      display: block;
-      padding: 0.5rem;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-    .choices input:focus + label,
-    .choices label:hover {
-      border-color: var(--accent);
-    }
-    #feedback {
-      margin-top: 1rem;
-      min-height: 1.5rem;
-    }
-    .correct {
-      color: var(--correct);
-    }
-    .incorrect {
-      color: var(--error);
-    }
-    .hidden { display:none; }
-    table {
-      border-collapse: collapse;
-      width: 100%;
-    }
-    th, td {
-      border: 1px solid #ccc;
-      padding: 0.25rem 0.5rem;
-    }
-    .modal {
-      position: fixed;
-      top:0;left:0;right:0;bottom:0;
-      background: rgba(0,0,0,0.5);
-      display:none;
-      align-items: center;
-      justify-content: center;
-    }
-    .modal .content {
-      background: var(--bg);
-      color: var(--fg);
-      max-height: 90vh;
-      overflow-y: auto;
-      padding:1rem;
-      border-radius:8px;
-      width: 90%;
-      max-width: 800px;
-    }
-    .progress-bar {
-      width: 100%;
-      height: 20px;
-      background: #ddd;
-      border-radius: 10px;
-      overflow: hidden;
-      margin-bottom: 1rem;
-    }
-    .progress-bar div {
-      height: 100%;
-      background: var(--accent);
-      width: 0%;
-    }
-    .focus-visible:focus {outline:2px solid var(--accent);}
-  </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SC-200 Practice</title>
+<style>
+  /* Basic layout */
+  body{font-family:Arial,Helvetica,sans-serif;margin:0;background:#f7f7f7;color:#222;display:flex;flex-direction:column;min-height:100vh;}
+  header{background:#004578;color:#fff;padding:.5rem;display:flex;flex-wrap:wrap;align-items:center;gap:.5rem;}
+  header h1{font-size:1.2rem;margin-right:auto;}
+  header button,header select,header input{font-size:.9rem;padding:.3rem .5rem;}
+  #progress{flex:1;margin-left:.5rem;height:8px;background:#ccc;border-radius:4px;overflow:hidden;}
+  #progress div{height:100%;width:0;background:#0078d4;}
+  #timer,#score{margin-left:.5rem;}
+  main{flex:1;padding:1rem;display:flex;flex-direction:column;}
+  .question{font-size:1.1rem;margin-bottom:1rem;}
+  .options{display:flex;flex-direction:column;gap:.5rem;}
+  .option{padding:.6rem;border:1px solid #999;border-radius:6px;background:#fff;cursor:pointer;text-align:left;}
+  .option[aria-checked="true"],.option:focus{outline:2px solid #0078d4;}
+  .option.correct{border-color:#0a0;background:#e6ffe6;}
+  .option.incorrect{border-color:#c00;background:#ffe6e6;}
+  .hidden{display:none;}
+  #explanation{margin-top:1rem;border-top:1px solid #ddd;padding-top:.5rem;}
+  footer{padding:.5rem;background:#eee;display:flex;align-items:center;gap:1rem;}
+  footer button{padding:.4rem .8rem;}
+  .modal{position:fixed;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.5);}
+  .modal .box{background:#fff;color:#222;padding:1rem;border-radius:8px;max-width:90%;max-height:90%;overflow:auto;}
+  table{border-collapse:collapse;width:100%;}
+  th,td{border:1px solid #ccc;padding:.3rem;text-align:left;}
+  @media(max-width:600px){header{flex-direction:column;align-items:flex-start;}#progress{width:100%;margin:0.5rem 0;}}
+  @media print{header,footer,.modal{display:none;}body{background:#fff;color:#000;}}
+</style>
 </head>
 <body>
-  <div id="topbar">
-    <button id="importBtn">Import</button>
-    <button id="exportJsonBtn">Export JSON</button>
-    <button id="exportCsvBtn">Export CSV</button>
-    <label>Mode:
-      <select id="modeSelect">
-        <option value="practice">Practice</option>
-        <option value="exam">Exam</option>
-        <option value="review">Review</option>
-      </select>
-    </label>
-    <label>Difficulty:
-      <select id="difficultyFilter"><option value="">All</option><option>easy</option><option>medium</option><option>hard</option></select>
-    </label>
-    <label>Tags:
-      <input id="tagFilter" placeholder="tag1;tag2" size="10"/>
-    </label>
-    <button id="shuffleBtn">Shuffle</button>
-    <label><input type="checkbox" id="shuffleChoices"> Shuffle Choices</label>
-    <label><input type="checkbox" id="keepOrder"> Keep Order</label>
-    <button id="darkBtn">Dark</button>
-    <button id="resetBtn">Reset</button>
-    <button id="reviewBtn">Review Incorrect</button>
-    <input id="search" placeholder="Search..."/>
+<header>
+  <h1>SC-200 Practice</h1>
+  <input type="file" id="fileInput" accept=".csv" class="hidden" />
+  <button id="importBtn">Import CSV</button>
+  <select id="modeSelect">
+    <option value="study">Study</option>
+    <option value="test">Test</option>
+    <option value="cram">Cram</option>
+  </select>
+  <label>Shuffle Qs<input type="checkbox" id="shuffleQuestions"/></label>
+  <label>Shuffle Opts<input type="checkbox" id="shuffleOptions"/></label>
+  <label>Range <input type="number" id="rangeStart" min="1" style="width:4rem;">-<input type="number" id="rangeEnd" min="1" style="width:4rem;"></label>
+  <input type="text" id="keyword" placeholder="keyword"/>
+  <label><input type="checkbox" id="onlyUnanswered">Unanswered</label>
+  <label><input type="checkbox" id="onlyIncorrect">Incorrect</label>
+  <div id="timer">00:00</div>
+  <div id="score"></div>
+  <div id="progress"><div></div></div>
+</header>
+<main aria-live="polite">
+  <div id="quiz"></div>
+</main>
+<footer>
+  <button id="prevBtn">Previous</button>
+  <button id="nextBtn">Next</button>
+  <button id="bookmarkBtn">Bookmark</button>
+  <button id="resetSessionBtn">Reset session</button>
+  <button id="resetAllBtn">Reset all</button>
+  <button id="exportBtn">Export results CSV</button>
+</footer>
+
+<!-- Import summary modal -->
+<div class="modal" id="importModal" role="dialog" aria-modal="true">
+  <div class="box">
+    <h2>Import Summary</h2>
+    <div id="importSummary"></div>
+    <h3>Preview</h3>
+    <table id="previewTable"></table>
+    <h3>Skipped Rows</h3>
+    <div id="skippedList"></div>
+    <button id="useDataBtn">Use Questions</button>
+    <button class="close">Close</button>
   </div>
-  <div id="container">
-    <main>
-      <div id="questionText"></div>
-      <button id="hintBtn" class="hidden">Show hint</button>
-      <div id="hint" class="hidden"></div>
-      <ul id="choices" class="choices"></ul>
-      <div>
-        <button id="confirmBtn">Confirm</button>
-        <button id="nextBtn" class="hidden">Next</button>
-        <button id="bookmarkBtn">Bookmark</button>
-      </div>
-      <div id="feedback"></div>
-    </main>
-    <aside>
-      <div class="progress-bar"><div id="progress"></div></div>
-      <div id="score">Score: 0/0</div>
-      <div id="timer" class="hidden">00:00</div>
-      <h3>Tag Accuracy</h3>
-      <table id="tagTable"></table>
-    </aside>
+</div>
+
+<!-- Results modal -->
+<div class="modal" id="resultsModal" role="dialog" aria-modal="true">
+  <div class="box">
+    <h2>Results</h2>
+    <div id="resultSummary"></div>
+    <div id="breakdown"></div>
+    <button id="restartBtn">Restart quiz</button>
+    <button id="reviewIncorrectBtn">Review incorrect</button>
+    <button class="close">Close</button>
   </div>
-  <div id="importModal" class="modal" role="dialog" aria-modal="true">
-    <div class="content">
-      <h2>Import Preview</h2>
-      <div id="importErrors" class="incorrect"></div>
-      <table id="importTable"></table>
-      <button id="importCommit">Commit</button>
-      <button class="closeModal">Close</button>
-    </div>
+</div>
+
+<!-- Review modal -->
+<div class="modal" id="reviewModal" role="dialog" aria-modal="true">
+  <div class="box">
+    <h2>Review</h2>
+    <div id="reviewContainer"></div>
+    <button class="close">Close</button>
   </div>
-  <div id="settingsModal" class="modal" role="dialog" aria-modal="true">
-    <div class="content">
-      <h2>Settings</h2>
-      <label><input type="checkbox" id="showHintsSetting"> Show hints by default</label>
-      <div>
-        <button id="saveSetBtn">Save current filter as set</button>
-      </div>
-      <div>
-        Saved Sets:
-        <ul id="setList"></ul>
-      </div>
-      <button class="closeModal">Close</button>
-    </div>
-  </div>
-  <div id="shortcutsModal" class="modal" role="dialog" aria-modal="true">
-    <div class="content">
-      <h2>Keyboard Shortcuts</h2>
-      <ul>
-        <li>1-6: choose answer</li>
-        <li>Enter: confirm/next</li>
-        <li>B: bookmark</li>
-        <li>S: shuffle</li>
-        <li>R: review incorrect</li>
-        <li>E: toggle exam mode</li>
-      </ul>
-      <button class="closeModal">Close</button>
-    </div>
-  </div>
-  <div id="setModal" class="modal" role="dialog" aria-modal="true">
-    <div class="content">
-      <h2>Save Set</h2>
-      <input id="setName" placeholder="Set name"/>
-      <button id="setSave">Save</button>
-      <button class="closeModal">Cancel</button>
-    </div>
-  </div>
-  <input type="file" id="fileInput" accept=".csv,.json" class="hidden"/>
-  <script>
-  (()=>{ // Storage Module
-    const KEY='mcqApp';
-    function load(){
-      try{ return JSON.parse(localStorage.getItem(KEY))||{}; }catch(e){ return {}; }
-    }
-    function save(data){ localStorage.setItem(KEY,JSON.stringify(data)); }
-    window.AppStorage={load,save,KEY};
-  })();
+</div>
 
-  (()=>{ // Data Module
-    const defaultQuestions=[
-      {id:'q1',question:'What is 2 + 2?',choices:['3','4','5','6'],answerIndex:1,explanation:'2+2=4',tags:['math'],difficulty:'easy',hint:'Think of addition'},
-      {id:'q2',question:'Capital of France?',choices:['Berlin','Paris','Rome','Madrid'],answerIndex:1,explanation:'Paris is the capital of France',tags:['geography'],difficulty:'easy'},
-      {id:'q3',question:'Which planet is known as the Red Planet?',choices:['Mars','Venus','Jupiter','Saturn'],answerIndex:0,explanation:'Mars is red',tags:['space'],difficulty:'easy'},
-      {id:'q4',question:'HTML stands for?',choices:['Hyperlinks and Text Markup Language','Hyper Text Markup Language','Home Tool Markup Language'],answerIndex:1,explanation:'Standard markup language',tags:['tech'],difficulty:'medium',hint:'Common web term'},
-      {id:'q5',question:'The powerhouse of the cell?',choices:['Nucleus','Mitochondria','Ribosome','Golgi apparatus'],answerIndex:1,explanation:'Mitochondria produce energy',tags:['biology'],difficulty:'easy'},
-      {id:'q6',question:'Derivative of sin(x)?',choices:['cos(x)','-cos(x)','sin(x)','-sin(x)'],answerIndex:0,explanation:'Derivative of sin is cos',tags:['math'],difficulty:'medium'}
-    ];
-    let state = AppStorage.load();
-    if(!state.questions) state.questions=defaultQuestions;
-    if(!state.results) state.results=[];
-    if(!state.bookmarks) state.bookmarks={};
-    if(!state.settings) state.settings={dark:false, showHints:false, shuffleQuestions:false, shuffleChoices:false};
-    if(!state.sets) state.sets={};
-    if(!state.incorrect) state.incorrect={};
-    AppStorage.save(state);
+<script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-rLAFH3b0x0Ygn+GJPD7W82dManIeZDV4SSQdlqzTeWY5Avzkdxl3pNGdisz8Iky3Uczdlz7YT1Do1B4ezwIJ1Q==" crossorigin="anonymous"></script>
+<script>
+(function(){
+  const deckKey='mcqDeck';
+  let allQuestions=[]; // full dataset with state
+  let quizQuestions=[]; // current filtered set
+  let index=0; // current question index
+  let mode='study';
+  let timer=null,startTime=0;
+  let results=[]; // for export
 
-    function getQuestions(){return state.questions;}
-    function setQuestions(q){state.questions=q;AppStorage.save(state);}
-    function addQuestions(qs){state.questions=state.questions.concat(qs);AppStorage.save(state);}
-    function toggleBookmark(id){ if(state.bookmarks[id]) delete state.bookmarks[id]; else state.bookmarks[id]=true; AppStorage.save(state); }
-    function isBookmarked(id){ return !!state.bookmarks[id]; }
-    function saveResult(res){ state.results.push(res); AppStorage.save(state); }
-    function getSettings(){ return state.settings; }
-    function updateSettings(s){ state.settings=Object.assign(state.settings,s); AppStorage.save(state); }
-    function saveSet(name,ids){ state.sets[name]=ids; AppStorage.save(state); }
-    function getSets(){ return state.sets; }
-    function markQuestion(id,isCorrect){
-      if(isCorrect) delete state.incorrect[id];
-      else state.incorrect[id]=true;
-      AppStorage.save(state);
-    }
-    function getIncorrect(){ return state.incorrect; }
-    function reset(){ localStorage.removeItem(AppStorage.KEY); location.reload(); }
-    window.Data={getQuestions,setQuestions,addQuestions,toggleBookmark,isBookmarked,saveResult,getSettings,updateSettings,saveSet,getSets,markQuestion,getIncorrect,reset,state};
-  })();
+  const quizEl=document.getElementById('quiz');
+  const progressBar=document.querySelector('#progress div');
+  const timerEl=document.getElementById('timer');
+  const scoreEl=document.getElementById('score');
 
-  (()=>{ // Parsing Module
-    function parseCSV(text){
-      const lines=text.trim().split(/\r?\n/);
-      const header=lines.shift().split(',');
-      const required=['question','choiceA','choiceB','answerIndex'];
-      for(let r of required){ if(!header.includes(r)) throw new Error('Missing column '+r); }
-      const idx={}; header.forEach((h,i)=>idx[h]=i);
-      const out=[]; const errors=[];
-      lines.forEach((line,ln)=>{
-        if(!line.trim()) return;
-        const cells=line.split(',');
-        try{
-          const question=cells[idx.question];
-          const choices=[];
-          ['choiceA','choiceB','choiceC','choiceD','choiceE','choiceF'].forEach(k=>{ if(idx[k]!=null&&cells[idx[k]]) choices.push(cells[idx[k]]); });
-          if(choices.length<2) throw new Error('Need at least 2 choices');
-          const answerIndex=parseInt(cells[idx.answerIndex]);
-          if(isNaN(answerIndex)||answerIndex>=choices.length) throw new Error('Invalid answerIndex');
-          const explanation=idx.explanation!=null?cells[idx.explanation]:'';
-          const tags=idx.tags!=null&&cells[idx.tags]?cells[idx.tags].split(';').filter(Boolean):[];
-          const difficulty=idx.difficulty!=null&&cells[idx.difficulty]?cells[idx.difficulty]:'easy';
-          const id='q'+Math.random().toString(36).slice(2,9);
-          out.push({id,question,choices,answerIndex,explanation,tags,difficulty});
-        }catch(e){ errors.push('Line '+(ln+2)+': '+e.message); }
-      });
-      return {questions:out,errors};
-    }
-    function parseJSON(text){
-      const arr=JSON.parse(text);
-      if(!Array.isArray(arr)) throw new Error('JSON must be array');
-      const errors=[]; const out=[];
-      arr.forEach((q,i)=>{
-        if(!q.question||!Array.isArray(q.choices)||q.choices.length<2||q.answerIndex==null){ errors.push('Index '+i+': invalid'); return; }
-        q.id=q.id||'q'+Math.random().toString(36).slice(2,9);
-        q.tags=q.tags||[];
-        q.difficulty=q.difficulty||'easy';
-        out.push(q);
-      });
-      return {questions:out,errors};
-    }
-    window.Parser={parseCSV,parseJSON};
-  })();
+  /* Utility */
+  function shuffle(arr){for(let i=arr.length-1;i>0;i--){const j=Math.floor(Math.random()* (i+1));[arr[i],arr[j]]=[arr[j],arr[i]];}return arr;}
 
-  (()=>{ // UI & Controller
-    const qEl=document.getElementById('questionText');
-    const choicesEl=document.getElementById('choices');
-    const feedbackEl=document.getElementById('feedback');
-    const progressBar=document.getElementById('progress');
-    const scoreEl=document.getElementById('score');
-    const timerEl=document.getElementById('timer');
-    const hintBtn=document.getElementById('hintBtn');
-    const hintEl=document.getElementById('hint');
-    const reviewBtn=document.getElementById('reviewBtn');
-    let questions=[]; let index=0; let correct=0; let startTime=0; let timerInterval=null; let mode='practice'; let answered=false; let order=[];
-
-    function loadSession(){
-      const all=Data.getQuestions();
-      const settings=Data.getSettings();
-      if(settings.shuffleQuestions) questions=shuffleArray([...all]); else questions=[...all];
-      order=questions.map((_,i)=>i);
-      applyFilters();
-      renderSets();
-      renderQuestion();
-      updateReviewBtn();
-      document.body.classList.toggle('dark',settings.dark);
-      document.getElementById('shuffleChoices').checked=settings.shuffleChoices;
-      document.getElementById('keepOrder').checked=!settings.shuffleQuestions;
-    }
-
-    function applyFilters(){
-      const tagFilter=document.getElementById('tagFilter').value.split(';').filter(Boolean);
-      const diff=document.getElementById('difficultyFilter').value;
-      const search=document.getElementById('search').value.toLowerCase();
-      const all=Data.getQuestions();
-      questions=all.filter(q=>{
-        if(tagFilter.length && !tagFilter.every(t=>q.tags.includes(t))) return false;
-        if(diff && q.difficulty!==diff) return false;
-        if(search && !q.question.toLowerCase().includes(search)) return false;
-        if(mode==='review' && !Data.getIncorrect()[q.id]) return false;
-        return true;
-      });
-      if(document.getElementById('keepOrder').checked){} else if(document.getElementById('shuffleBtn').dataset.active==='1'||Data.getSettings().shuffleQuestions) questions=shuffleArray([...questions]);
-      index=0;correct=0;answered=false;
-    }
-
-    function shuffleArray(arr){
-      for(let i=arr.length-1;i>0;i--){const j=Math.floor(Math.random()* (i+1));[arr[i],arr[j]]=[arr[j],arr[i]];}return arr;
-    }
-
-    function renderQuestion(){
-      if(index>=questions.length){ showResult(); return; }
-      const q=questions[index];
-      qEl.textContent=q.question;
-      hintEl.textContent=q.hint||''; hintBtn.classList.toggle('hidden',!q.hint);
-      hintEl.classList.add('hidden');
-      choicesEl.innerHTML='';
-      let choiceOrder=q.choices.map((c,i)=>({c,i}));
-      if(document.getElementById('shuffleChoices').checked && !document.getElementById('keepOrder').checked){ choiceOrder=shuffleArray(choiceOrder); }
-      choiceOrder.forEach(({c,i},idx)=>{
-        const li=document.createElement('li');
-        const id='choice'+idx;
-        li.innerHTML='<input type="radio" name="choice" id="'+id+'" value="'+i+'"/><label for="'+id+'">'+c+'</label>';
-        choicesEl.appendChild(li);
-      });
-      feedbackEl.textContent='';
-      document.getElementById('confirmBtn').classList.remove('hidden');
-      document.getElementById('nextBtn').classList.add('hidden');
-      scoreEl.textContent='Score: '+correct+'/'+questions.length;
-      progressBar.style.width=((index)/questions.length*100)+'%';
-    }
-
-    function confirm(){
-      const sel=document.querySelector('input[name="choice"]:checked');
-      if(!sel){alert('Select an option');return;}
-      const q=questions[index];
-      answered=true;
-      const isCorrect=parseInt(sel.value)===q.answerIndex;
-      if(isCorrect){
-        feedbackEl.textContent='Correct! '+(q.explanation||'');
-        feedbackEl.className='correct';
-        correct++;}
-      else{
-        feedbackEl.textContent='Incorrect. '+(q.explanation||'');
-        feedbackEl.className='incorrect';
-      }
-      Data.markQuestion(q.id,isCorrect);
-      if(mode==='review' && isCorrect){questions.splice(index,1);index--;}
-      document.getElementById('confirmBtn').classList.add('hidden');
-      document.getElementById('nextBtn').classList.remove('hidden');
-      progressBar.style.width=((index+1)/questions.length*100)+'%';
-      scoreEl.textContent='Score: '+correct+'/'+questions.length;
-    }
-
-    function next(){ index++; answered=false; renderQuestion(); }
-
-    function showResult(){
-      const percent=Math.round(correct/questions.length*100);
-      qEl.textContent='Finished! Score '+percent+'%';
-      choicesEl.innerHTML='';
-      document.getElementById('confirmBtn').classList.add('hidden');
-      document.getElementById('nextBtn').classList.add('hidden');
-      Data.saveResult({mode,correct,total:questions.length,date:Date.now()});
-    }
-
-    document.getElementById('confirmBtn').addEventListener('click',confirm);
-    document.getElementById('nextBtn').addEventListener('click',next);
-    document.getElementById('bookmarkBtn').addEventListener('click',()=>{const q=questions[index];Data.toggleBookmark(q.id);});
-    document.getElementById('importBtn').addEventListener('click',()=>document.getElementById('fileInput').click());
-    document.getElementById('fileInput').addEventListener('change',handleFile);
-    document.getElementById('exportJsonBtn').addEventListener('click',()=>{
-      const blob=new Blob([JSON.stringify(Data.getQuestions(),null,2)],{type:'application/json'});
-      const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='questions.json';a.click();
+  function parseCsv(file){
+    return new Promise((resolve,reject)=>{
+      Papa.parse(file,{header:true,skipEmptyLines:true,complete:res=>resolve(res),error:err=>reject(err)});
     });
-    document.getElementById('exportCsvBtn').addEventListener('click',()=>{
-      const qs=Data.getQuestions();
-      let csv='question,choiceA,choiceB,choiceC,choiceD,answerIndex,explanation,tags,difficulty\n';
-      qs.forEach(q=>{const row=[q.question,...q.choices, q.answerIndex, q.explanation||'', q.tags.join(';'), q.difficulty];csv+=row.map(v=>'"'+(v||'').replace(/"/g,'""')+'"').join(',')+'\n';});
-      const blob=new Blob([csv],{type:'text/csv'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='questions.csv';a.click();
+  }
+
+  function validateRows(res){
+    const required=['QuestionNumber','Question','Option A','Option B','Option C','Option D','Shown Answer','Correct Answer','Explanation'];
+    if(JSON.stringify(res.meta.fields)!==JSON.stringify(required)){
+      throw new Error('CSV columns mismatch. Expect header: '+required.join(', '));
+    }
+    const seen=new Set();
+    const valid=[],skipped=[];
+    res.data.forEach((row,i)=>{
+      const num=row['QuestionNumber'];
+      if(seen.has(num)){skipped.push({row:i+2,reason:'Duplicate QuestionNumber'});return;}
+      seen.add(num);
+      const opts=['Option A','Option B','Option C','Option D'].map(k=>row[k]);
+      const filled=opts.filter(o=>o!==undefined && o!==null && o!=='' );
+      if(filled.length<2){skipped.push({row:i+2,reason:'<2 options'});return;}
+      const correct=(row['Correct Answer']||'').trim().toUpperCase();
+      const letters=['A','B','C','D'];
+      const correctIdx=letters.indexOf(correct);
+      if(correctIdx===-1||!opts[correctIdx]){skipped.push({row:i+2,reason:'Invalid Correct Answer'});return;}
+      valid.push(normalizeQuestion(row,opts,correctIdx));
     });
-    document.getElementById('shuffleBtn').addEventListener('click',()=>{document.getElementById('shuffleBtn').dataset.active=document.getElementById('shuffleBtn').dataset.active==='1'?'0':'1';applyFilters();renderQuestion();});
-    document.getElementById('darkBtn').addEventListener('click',()=>{document.body.classList.toggle('dark');Data.updateSettings({dark:document.body.classList.contains('dark')});});
-    document.getElementById('keepOrder').addEventListener('change',()=>{Data.updateSettings({shuffleQuestions:!document.getElementById('keepOrder').checked});applyFilters();renderQuestion();});
-    document.getElementById('shuffleChoices').addEventListener('change',()=>{Data.updateSettings({shuffleChoices:document.getElementById('shuffleChoices').checked});renderQuestion();});
-    document.getElementById('difficultyFilter').addEventListener('change',()=>{applyFilters();renderQuestion();});
-    document.getElementById('tagFilter').addEventListener('change',()=>{applyFilters();renderQuestion();});
-    document.getElementById('search').addEventListener('input',()=>{applyFilters();renderQuestion();});
-    document.getElementById('resetBtn').addEventListener('click',()=>{if(confirm('Reset everything?')) Data.reset();});
-    reviewBtn.addEventListener('click',()=>{if(reviewBtn.disabled) return;mode='review';document.getElementById('modeSelect').value='review';stopTimer();applyFilters();renderQuestion();});
+    return {valid,skipped};
+  }
 
-    hintBtn.addEventListener('click',()=>hintEl.classList.toggle('hidden'));
+  function normalizeQuestion(row,opts,correctIdx){
+    return {
+      num:row['QuestionNumber'],
+      text:row['Question'],
+      options:opts.map((t,i)=>({text:t,letter:['A','B','C','D'][i]})),
+      correctIndex:correctIdx,
+      explanation:row['Explanation']||'',
+      shownAnswer:row['Shown Answer']||'',
+      chosen:null,
+      bookmarked:false
+    };
+  }
 
-    document.addEventListener('keydown',e=>{
-      const num=parseInt(e.key)-1;
-      if(num>=0&&num<6){ const input=document.querySelectorAll('input[name="choice"]')[num]; if(input){input.checked=true;} }
-      if(e.key==='Enter'){ answered?next():confirm(); }
-      if(e.key==='b'||e.key==='B') document.getElementById('bookmarkBtn').click();
-      if(e.key==='s'||e.key==='S'){document.getElementById('shuffleBtn').click();}
-      if(e.key==='r'||e.key==='R'){document.getElementById('modeSelect').value='review';mode='review';stopTimer();applyFilters();renderQuestion();}
-      if(e.key==='e'||e.key==='E'){document.getElementById('modeSelect').value='exam';mode='exam';applyFilters();renderQuestion();startTimer();}
-    });
+  function saveState(){localStorage.setItem(deckKey,JSON.stringify(allQuestions));}
+  function loadState(){const d=localStorage.getItem(deckKey);if(d){allQuestions=JSON.parse(d);} }
+  function resetSession(){allQuestions.forEach(q=>{q.chosen=null;q.bookmarked=false;});saveState();}
+  function resetAll(){localStorage.clear();location.reload();}
 
-    function startTimer(){startTime=Date.now();timerEl.classList.remove('hidden');timerInterval=setInterval(()=>{const s=Math.floor((Date.now()-startTime)/1000);timerEl.textContent=('0'+Math.floor(s/60)).slice(-2)+':'+('0'+(s%60)).slice(-2);},1000);}
-    function stopTimer(){timerEl.classList.add('hidden');clearInterval(timerInterval);}
+  function applyFilters(){
+    let qs=[...allQuestions];
+    const start=parseInt(document.getElementById('rangeStart').value)||-Infinity;
+    const end=parseInt(document.getElementById('rangeEnd').value)||Infinity;
+    qs=qs.filter(q=>q.num>=start && q.num<=end);
+    const kw=document.getElementById('keyword').value.toLowerCase();
+    if(kw) qs=qs.filter(q=>q.text.toLowerCase().includes(kw)||q.explanation.toLowerCase().includes(kw));
+    if(document.getElementById('onlyUnanswered').checked) qs=qs.filter(q=>q.chosen==null);
+    if(document.getElementById('onlyIncorrect').checked) qs=qs.filter(q=>q.chosen!=null && q.chosen!==q.correctIndex);
+    if(document.getElementById('shuffleQuestions').checked) shuffle(qs);
+    return qs;
+  }
 
-    function handleFile(e){
-      const file=e.target.files[0]; if(!file) return;
-      const reader=new FileReader();
-      reader.onload=evt=>{
-        let res;
-        try{
-          if(file.name.endsWith('.csv')) res=Parser.parseCSV(evt.target.result); else res=Parser.parseJSON(evt.target.result);
-          showImportPreview(res.questions,res.errors);
-        }catch(err){alert(err.message);} }
-      reader.readAsText(file);
+  function shuffleOptions(q){
+    const arr=q.options;
+    const correctText=arr[q.correctIndex].text;
+    shuffle(arr);
+    q.correctIndex=arr.findIndex(o=>o.text===correctText);
+  }
+
+  function startQuiz(m){
+    mode=m;results=[];index=0;quizQuestions=applyFilters().map(q=>({...q}));
+    if(document.getElementById('shuffleOptions').checked) quizQuestions.forEach(shuffleOptions);
+    startTime=Date.now();timerEl.textContent='00:00';clearInterval(timer);timer=setInterval(()=>{const s=Math.floor((Date.now()-startTime)/1000);timerEl.textContent=('0'+Math.floor(s/60)).slice(-2)+':'+('0'+s%60).slice(-2);},1000);
+    renderQuestion();updateScore();
+  }
+
+  function renderQuestion(){
+    if(index>=quizQuestions.length){finishQuiz();return;}
+    const q=quizQuestions[index];
+    let html='<div class="question">'+q.text+'</div>';
+    if(mode==='cram' && !q.showing){html+='<button id="revealBtn">Reveal options</button>';quizEl.innerHTML=html;document.getElementById('revealBtn').onclick=()=>{q.showing=true;renderQuestion();};return;}
+    html+='<div id="options" role="radiogroup" class="options">';
+    q.options.forEach((o,i)=>{html+='<button class="option" role="radio" data-index="'+i+'" aria-checked="false">'+String.fromCharCode(65+i)+'. '+o.text+'</button>';});
+    html+='</div><div id="feedback" aria-live="polite"></div>';
+    html+='<details id="explanation" class="hidden"><summary>Explanation</summary>'+q.explanation+'</details>';
+    quizEl.innerHTML=html;
+    Array.from(document.querySelectorAll('.option')).forEach(btn=>btn.addEventListener('click',()=>selectOption(btn)));
+    document.addEventListener('keydown',keyHandler);
+    updateProgress();
+  }
+
+  let selected=-1;
+  function selectOption(btn){
+    document.querySelectorAll('.option').forEach(b=>{b.setAttribute('aria-checked','false');b.classList.remove('selected');});
+    btn.setAttribute('aria-checked','true');btn.classList.add('selected');selected=parseInt(btn.dataset.index);
+  }
+
+  function keyHandler(e){
+    const opts=document.querySelectorAll('.option');
+    if(['ArrowDown','ArrowRight'].includes(e.key)){if(selected<opts.length-1){selectOption(opts[selected+1]||opts[0]);}}
+    if(['ArrowUp','ArrowLeft'].includes(e.key)){if(selected>0){selectOption(opts[selected-1]||opts[opts.length-1]);}}
+    const num=parseInt(e.key)-1;if(num>=0 && num<opts.length){selectOption(opts[num]);}
+    if(e.key==='Enter'){submitAnswer();}
+  }
+
+  function submitAnswer(){
+    const q=quizQuestions[index];
+    if(selected<0) return;
+    q.chosen=selected;
+    const correct=selected===q.correctIndex;
+    allQuestions.find(x=>x.num===q.num).chosen=selected;
+    saveState();
+    results.push({QuestionNumber:q.num,ChosenAnswer:String.fromCharCode(65+selected),CorrectAnswer:String.fromCharCode(65+q.correctIndex),IsCorrect:correct,Mode:mode,Timestamp:new Date().toISOString()});
+    if(mode==='study'||mode==='cram'){
+      const opts=document.querySelectorAll('.option');
+      opts[q.correctIndex].classList.add('correct');
+      if(!correct) opts[selected].classList.add('incorrect');
+      document.getElementById('feedback').textContent=correct?'Correct':'Incorrect';
+      document.getElementById('explanation').classList.remove('hidden');
     }
+    updateScore();
+    document.removeEventListener('keydown',keyHandler);
+  }
 
-    function showImportPreview(qs,errors){
-      const modal=document.getElementById('importModal');
-      const table=document.getElementById('importTable');
-      const errEl=document.getElementById('importErrors');
-      table.innerHTML='';
-      const thead=document.createElement('tr'); ['Question','Choices','Answer','Tags','Difficulty'].forEach(h=>{const th=document.createElement('th');th.textContent=h;thead.appendChild(th);}); table.appendChild(thead);
-      qs.forEach(q=>{const tr=document.createElement('tr');tr.innerHTML='<td>'+q.question+'</td><td>'+q.choices.join('<br>')+'</td><td>'+q.answerIndex+'</td><td>'+q.tags.join(';')+'</td><td>'+q.difficulty+'</td>';table.appendChild(tr);});
-      errEl.innerHTML=errors.join('<br>');
-      modal.style.display='flex';
-      document.getElementById('importCommit').onclick=()=>{Data.addQuestions(qs);modal.style.display='none';applyFilters();renderQuestion();};
-    }
+  function next(){selected=-1;index++;renderQuestion();}
+  function prev(){if(index>0){index--;selected=-1;renderQuestion();}}
 
-    document.querySelectorAll('.modal .closeModal').forEach(btn=>btn.addEventListener('click',e=>e.target.closest('.modal').style.display='none'));
-    document.getElementById('saveSetBtn').addEventListener('click',()=>{document.getElementById('setModal').style.display='flex';});
-    document.getElementById('setSave').addEventListener('click',()=>{const name=document.getElementById('setName').value.trim();if(!name) return;const ids=questions.map(q=>q.id);Data.saveSet(name,ids);document.getElementById('setModal').style.display='none';renderSets();});
+  function updateProgress(){progressBar.style.width=((index)/quizQuestions.length*100)+'%';document.querySelector('header').setAttribute('aria-label','Question '+(index+1)+' of '+quizQuestions.length);}
+  function updateScore(){if(mode==='study'||mode==='cram'){const ans=results.filter(r=>r.IsCorrect).length;scoreEl.textContent=ans+'/'+quizQuestions.length;}};
 
-    function renderSets(){
-      const ul=document.getElementById('setList');
-      ul.innerHTML='';
-      const sets=Data.getSets();
-      Object.keys(sets).forEach(k=>{const li=document.createElement('li');const btn=document.createElement('button');btn.textContent=k;btn.onclick=()=>{questions=Data.getQuestions().filter(q=>sets[k].includes(q.id));index=0;correct=0;renderQuestion();};li.appendChild(btn);ul.appendChild(li);});
-    }
+  function finishQuiz(){clearInterval(timer);progressBar.style.width='100%';let correct=results.filter(r=>r.IsCorrect).length;const total=quizQuestions.length;const time=timerEl.textContent;document.getElementById('resultSummary').innerHTML=`Score ${correct}/${total} in ${time}`;const breakdown={A:0,B:0,C:0,D:0};results.forEach(r=>{breakdown[r.ChosenAnswer]++});let bd='';for(const k in breakdown){bd+=k+': '+breakdown[k]+'<br>';};document.getElementById('breakdown').innerHTML=bd;document.getElementById('resultsModal').style.display='flex';}
 
-    function updateReviewBtn(){
-      const count=Object.keys(Data.getIncorrect()).length;
-      reviewBtn.disabled=count===0;
-      reviewBtn.textContent='Review Incorrect ('+count+')';
-    }
+  function exportResultsCsv(){if(results.length===0)return;let csv='QuestionNumber,ChosenAnswer,CorrectAnswer,IsCorrect,Mode,Timestamp\n';results.forEach(r=>{csv+=`${r.QuestionNumber},${r.ChosenAnswer},${r.CorrectAnswer},${r.IsCorrect},${r.Mode},${r.Timestamp}\n`;});const blob=new Blob([csv],{type:'text/csv'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='results.csv';a.click();}
 
-    window.addEventListener('load',loadSession);
-  })();
-  </script>
+  function renderReview(filter){const qs=allQuestions.filter(q=>filter==='incorrect'?q.chosen!==null&&q.chosen!==q.correctIndex:q.bookmarked);let html='';qs.forEach(q=>{html+=`<div><strong>${q.num}. ${q.text}</strong><br>`;q.options.forEach((o,i)=>{const cls=i===q.correctIndex?'correct':(i===q.chosen?'incorrect':'');html+=`<div class="option ${cls}">${String.fromCharCode(65+i)}. ${o.text}</div>`;});html+=`<div>${q.explanation}</div><hr></div>`;});document.getElementById('reviewContainer').innerHTML=html||'None';document.getElementById('reviewModal').style.display='flex';}
+
+  /* Event bindings */
+  document.getElementById('importBtn').onclick=()=>document.getElementById('fileInput').click();
+  document.getElementById('fileInput').addEventListener('change',async e=>{const file=e.target.files[0];if(!file)return;try{const res=await parseCsv(file);const {valid,skipped}=validateRows(res);showImportSummary(valid,skipped);}catch(err){alert(err.message);}});
+
+  function showImportSummary(valid,skipped){document.getElementById('previewTable').innerHTML='';valid.slice(0,3).forEach(q=>{const tr=document.createElement('tr');tr.innerHTML=`<td>${q.num}</td><td>${q.text}</td>`;document.getElementById('previewTable').appendChild(tr);});document.getElementById('importSummary').textContent=`Imported ${valid.length} questions. Skipped ${skipped.length}.`;document.getElementById('skippedList').innerHTML=skipped.map(s=>`Row ${s.row}: ${s.reason}`).join('<br>');document.getElementById('importModal').style.display='flex';document.getElementById('useDataBtn').onclick=()=>{allQuestions=valid;saveState();document.getElementById('importModal').style.display='none';};}
+
+  document.querySelectorAll('.modal .close').forEach(btn=>btn.onclick=e=>e.target.closest('.modal').style.display='none');
+
+  document.getElementById('modeSelect').addEventListener('change',e=>startQuiz(e.target.value));
+  document.getElementById('nextBtn').onclick=()=>{if(selected===-1)submitAnswer();next();};
+  document.getElementById('prevBtn').onclick=prev;
+  document.getElementById('bookmarkBtn').onclick=()=>{const q=quizQuestions[index];q.bookmarked=!q.bookmarked;allQuestions.find(x=>x.num===q.num).bookmarked=q.bookmarked;saveState();};
+  document.getElementById('resetSessionBtn').onclick=()=>{if(confirm('Clear progress?')){resetSession();}};
+  document.getElementById('resetAllBtn').onclick=()=>{if(confirm('Clear all data?'))resetAll();};
+  document.getElementById('exportBtn').onclick=exportResultsCsv;
+  document.getElementById('restartBtn').onclick=()=>{document.getElementById('resultsModal').style.display='none';startQuiz(mode);};
+  document.getElementById('reviewIncorrectBtn').onclick=()=>{document.getElementById('resultsModal').style.display='none';renderReview('incorrect');};
+
+  document.getElementById('reviewModal').querySelector('.close').onclick=()=>document.getElementById('reviewModal').style.display='none';
+
+  loadState();if(allQuestions.length)startQuiz('study');
+
+  /* Acceptance tests (manual):
+    1. Import provided sample CSV. Expect preview first 3 questions and summary.
+    2. Toggle shuffle options and ensure correct answers remain valid.
+    3. Answer 5 questions in Test mode; finish and see results with explanations.
+    4. Filter by keyword 'Key Vault' to show only matching questions.
+    5. Bookmark two questions and open Review (bookmarked) via renderReview('bookmarked').
+    6. Export results CSV and check headers/rows.
+  */
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace existing index with a single-file SC-200 practice app
- Support CSV import/validation, study/test/cram modes, bookmarks and review
- Add localStorage persistence, results export, and keyboard-accessible UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd1f8aa4832c8c322ab77a93fc4f