### PR TITLE
Allow quiz to use imported questions

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
-import questions from './questions';
+import defaultQuestions from './questions';
 
 function Quiz() {
+  const [questions] = useState(() => {
+    try {
+      const stored = localStorage.getItem('questions');
+      const parsed = stored ? JSON.parse(stored) : null;
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    } catch {
+      // ignore parse errors and fall back to defaults
+    }
+    return defaultQuestions;
+  });
   const [current, setCurrent] = useState(0);
   const [selected, setSelected] = useState(null);
   const [score, setScore] = useState(0);


### PR DESCRIPTION
## Summary
- Parse uploaded CSV questions and store them in local storage
- Load stored questions for quizzes instead of always using defaults

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e4ec9c98832c9b94be83d5698fe4