### PR TITLE
feat: add dark mode and active navigation to quiz app

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -1,7 +1,3 @@
-body {
-  background: #f5f5f5;
-}
-
 .app {
   max-width: 600px;
   margin: 0 auto;
@@ -10,7 +6,7 @@ body {
 }
 
 .card {
-  background: #fff;
+  background: var(--card-bg);
   padding: 1.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -44,13 +40,13 @@ h1 {
 }
 
 .option label:hover {
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 
 .option label.selected {
-  background: #646cff;
+  background: var(--accent-color);
   color: #fff;
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 
 .next {
@@ -71,7 +67,7 @@ h1 {
 
 .progress-bar {
   height: 100%;
-  background: #646cff;
+  background: var(--accent-color);
   width: 0;
   transition: width 0.3s;
 }
@@ -96,18 +92,33 @@ h1 {
 
 .nav {
   display: flex;
-  gap: 1rem;
-  justify-content: center;
+  align-items: center;
   margin-bottom: 1rem;
 }
 
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  flex: 1;
+  justify-content: center;
+}
+
 .nav a {
-  color: #646cff;
+  color: var(--accent-color);
   text-decoration: none;
 }
 
 .nav a:hover {
   text-decoration: underline;
+}
+
+.nav a.active {
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.theme-toggle {
+  margin-left: 1rem;
 }
 
 .landing-buttons {

--- a/mcqproject/src/App.jsx
+++ b/mcqproject/src/App.jsx
@@ -1,20 +1,42 @@
 import './App.css';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import Quiz from './Quiz.jsx';
 import LandingPage from './LandingPage.jsx';
 import Settings from './Settings.jsx';
 import ImportQuestions from './Import.jsx';
 
 function App() {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem('theme') || 'light'
+  );
+
+  useEffect(() => {
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+  };
+
   return (
     <BrowserRouter>
       <div className="app">
         <h1>MCQ Practice</h1>
         <nav className="nav">
-          <Link to="/">Home</Link>
-          <Link to="/quiz">Quiz</Link>
-          <Link to="/settings">Settings</Link>
-          <Link to="/import">Import</Link>
+          <div className="nav-links">
+            <NavLink to="/" end>
+              Home
+            </NavLink>
+            <NavLink to="/quiz">Quiz</NavLink>
+            <NavLink to="/settings">Settings</NavLink>
+            <NavLink to="/import">Import</NavLink>
+          </div>
+          <button className="theme-toggle" onClick={toggleTheme}>
+            {theme === 'light' ? 'Dark' : 'Light'} Mode
+          </button>
         </nav>
         <Routes>
           <Route path="/" element={<LandingPage />} />

--- a/mcqproject/src/index.css
+++ b/mcqproject/src/index.css
@@ -6,14 +6,25 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: #213547;
+  --accent-color: #646cff;
+  --bg-color: #f5f5f5;
+  --text-color: #213547;
+  --card-bg: #fff;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: #ffffff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+body.dark {
+  --bg-color: #1a1a1a;
+  --text-color: #f5f5f5;
+  --card-bg: #242424;
+  --accent-color: #9499ff;
 }
 
 button {
@@ -23,12 +34,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #646cff;
+  background-color: var(--accent-color);
   color: white;
   cursor: pointer;
   transition: background-color 0.25s;
 }
 
 button:hover {
-  background-color: #535bf2;
+  filter: brightness(0.9);
 }


### PR DESCRIPTION
## Summary
- add dark/light theme toggle with persistence
- style navigation with active links and theme button
- refactor styles to use CSS variables for theme support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5fa4b84832cbcaec9bf0e658051