### PR TITLE
Add question editing and expanded settings

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -128,3 +128,17 @@ h1 {
   align-items: center;
   margin-top: 1rem;
 }
+
+.question-list {
+  list-style: none;
+  padding: 0;
+}
+
+.question-item {
+  border-bottom: 1px solid #ccc;
+  padding: 0.5rem 0;
+}
+
+.question-item button {
+  margin-right: 0.5rem;
+}

--- a/mcqproject/src/App.jsx
+++ b/mcqproject/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
             </NavLink>
             <NavLink to="/quiz">Quiz</NavLink>
             <NavLink to="/settings">Settings</NavLink>
-            <NavLink to="/import">Import</NavLink>
+            <NavLink to="/import">Questions</NavLink>
           </div>
           <button className="theme-toggle" onClick={toggleTheme}>
             {theme === 'light' ? 'Dark' : 'Light'} Mode

--- a/mcqproject/src/Import.jsx
+++ b/mcqproject/src/Import.jsx
@@ -1,8 +1,23 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 function ImportQuestions() {
   const [questions, setQuestions] = useState([]);
   const [error, setError] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [draft, setDraft] = useState({
+    question: '',
+    options: ['', '', '', ''],
+    answer: 0,
+  });
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('questions') || '[]');
+      setQuestions(stored);
+    } catch {
+      setQuestions([]);
+    }
+  }, []);
 
   const handleFile = (e) => {
     const file = e.target.files[0];
@@ -18,7 +33,7 @@ function ImportQuestions() {
             cols[5]?.trim().toUpperCase()
           );
           return {
-            id: idx + 1,
+            id: Date.now() + idx,
             question: cols[0],
             options: cols.slice(1, 5),
             answer,
@@ -35,16 +50,79 @@ function ImportQuestions() {
     reader.readAsText(file);
   };
 
+  const startEdit = (q) => {
+    setEditingId(q.id);
+    setDraft({ question: q.question, options: [...q.options], answer: q.answer });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+  };
+
+  const saveEdit = () => {
+    const updated = questions.map((q) =>
+      q.id === editingId ? { ...q, ...draft } : q
+    );
+    setQuestions(updated);
+    localStorage.setItem('questions', JSON.stringify(updated));
+    setEditingId(null);
+  };
+
+  const deleteQuestion = (id) => {
+    const updated = questions.filter((q) => q.id !== id);
+    setQuestions(updated);
+    localStorage.setItem('questions', JSON.stringify(updated));
+  };
+
   return (
     <div className="card">
-      <h2>Import Questions</h2>
+      <h2>Questions</h2>
       <input type="file" accept=".csv" onChange={handleFile} />
       {error && <p className="error">{error}</p>}
       {questions.length > 0 && <p>Loaded {questions.length} questions.</p>}
       {questions.length > 0 && (
-        <ul>
+        <ul className="question-list">
           {questions.map((q) => (
-            <li key={q.id}>{q.question}</li>
+            <li key={q.id} className="question-item">
+              {editingId === q.id ? (
+                <div>
+                  <textarea
+                    value={draft.question}
+                    onChange={(e) => setDraft({ ...draft, question: e.target.value })}
+                  />
+                  {draft.options.map((opt, idx) => (
+                    <div key={idx}>
+                      <input
+                        type="text"
+                        value={opt}
+                        onChange={(e) => {
+                          const opts = [...draft.options];
+                          opts[idx] = e.target.value;
+                          setDraft({ ...draft, options: opts });
+                        }}
+                      />
+                      <label>
+                        <input
+                          type="radio"
+                          name="answer"
+                          checked={draft.answer === idx}
+                          onChange={() => setDraft({ ...draft, answer: idx })}
+                        />
+                        Correct
+                      </label>
+                    </div>
+                  ))}
+                  <button onClick={saveEdit}>Save</button>
+                  <button onClick={cancelEdit}>Cancel</button>
+                </div>
+              ) : (
+                <div>
+                  <p>{q.question}</p>
+                  <button onClick={() => startEdit(q)}>Edit</button>
+                  <button onClick={() => deleteQuestion(q.id)}>Delete</button>
+                </div>
+              )}
+            </li>
           ))}
         </ul>
       )}

--- a/mcqproject/src/LandingPage.jsx
+++ b/mcqproject/src/LandingPage.jsx
@@ -7,7 +7,7 @@ function LandingPage() {
       <div className="landing-buttons">
         <Link to="/quiz"><button>Start Quiz</button></Link>
         <Link to="/settings"><button>Settings</button></Link>
-        <Link to="/import"><button>Import</button></Link>
+        <Link to="/import"><button>Questions</button></Link>
       </div>
     </div>
   );

--- a/mcqproject/src/Settings.jsx
+++ b/mcqproject/src/Settings.jsx
@@ -1,7 +1,32 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 function Settings() {
   const [numQuestions, setNumQuestions] = useState(3);
+  const [shuffleQs, setShuffleQs] = useState(() => localStorage.getItem('shuffleQs') === 'true');
+  const [shuffleOpts, setShuffleOpts] = useState(() => localStorage.getItem('shuffleOpts') === 'true');
+
+  useEffect(() => {
+    localStorage.setItem('shuffleQs', shuffleQs);
+  }, [shuffleQs]);
+
+  useEffect(() => {
+    localStorage.setItem('shuffleOpts', shuffleOpts);
+  }, [shuffleOpts]);
+
+  const count = (() => {
+    try {
+      return JSON.parse(localStorage.getItem('questions') || '[]').length;
+    } catch {
+      return 0;
+    }
+  })();
+
+  const clearQuestions = () => {
+    if (window.confirm('Delete all questions?')) {
+      localStorage.removeItem('questions');
+      window.location.reload();
+    }
+  };
 
   return (
     <div className="card">
@@ -15,6 +40,24 @@ function Settings() {
           onChange={(e) => setNumQuestions(e.target.value)}
         />
       </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={shuffleQs}
+          onChange={(e) => setShuffleQs(e.target.checked)}
+        />
+        Shuffle questions
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={shuffleOpts}
+          onChange={(e) => setShuffleOpts(e.target.checked)}
+        />
+        Shuffle options
+      </label>
+      <p>Loaded questions: {count}</p>
+      {count > 0 && <button onClick={clearQuestions}>Clear All</button>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Allow editing and deleting imported questions
- Expand settings with shuffle options and question count
- Rename navigation to clarify question management

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e8d73480832ca11ea21068fb9bc5