### PR TITLE
Add explanation field for questions and show after selection

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -53,6 +53,10 @@ h1 {
   margin-top: 1rem;
 }
 
+.explanation {
+  margin-top: 1rem;
+}
+
 .result {
   text-align: center;
 }

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -108,6 +108,9 @@ function Quiz() {
           </li>
         ))}
       </ul>
+      {selected !== null && (
+        <p className="explanation">{question.explanation}</p>
+      )}
       <button className="next" onClick={handleNext} disabled={selected === null}>
         {current + 1 === questions.length ? 'Finish' : 'Next'}
       </button>

--- a/mcqproject/src/questions.js
+++ b/mcqproject/src/questions.js
@@ -4,18 +4,21 @@ const questions = [
     question: 'What is the capital of France?',
     options: ['Berlin', 'Paris', 'Rome', 'Madrid'],
     answer: 1,
+    explanation: 'Paris is the capital and most populous city of France.',
   },
   {
     id: 2,
     question: 'Which planet is known as the Red Planet?',
     options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
     answer: 1,
+    explanation: 'Mars is called the Red Planet due to its reddish appearance.',
   },
   {
     id: 3,
     question: 'What is 2 + 2?',
     options: ['3', '4', '5', '6'],
     answer: 1,
+    explanation: 'Adding 2 and 2 gives 4.',
   },
 ];
 

--- a/mcqproject/test/questions.test.js
+++ b/mcqproject/test/questions.test.js
@@ -6,3 +6,10 @@ test('questions array has expected length', () => {
   assert.ok(Array.isArray(questions));
   assert.strictEqual(questions.length, 3);
 });
+
+test('each question includes an explanation', () => {
+  for (const q of questions) {
+    assert.strictEqual(typeof q.explanation, 'string');
+    assert.notStrictEqual(q.explanation.length, 0);
+  }
+});


### PR DESCRIPTION
## Summary
- Add explanation text to default questions
- Display explanation when an answer option is selected
- Include style and test coverage for question explanations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea084bc0832c9c0d5f7301400f4c