### PR TITLE
feat: refresh UI styling

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -1,19 +1,47 @@
 .app {
-  max-width: 600px;
+  max-width: 700px;
   margin: 0 auto;
   padding: 2rem;
-  font-family: system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .card {
   background: var(--card-bg);
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.75rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s;
+  animation: fadeIn 0.4s ease;
+}
+
+.card:hover {
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.15);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 h1 {
   text-align: center;
+  margin-bottom: 1rem;
+  background: linear-gradient(90deg, var(--accent-color), #b488ff);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+h2 {
+  color: var(--accent-color);
+  margin-top: 0;
 }
 
 .options {
@@ -71,7 +99,7 @@ h1 {
 
 .progress-bar {
   height: 100%;
-  background: var(--accent-color);
+  background: linear-gradient(90deg, var(--accent-color), #b488ff);
   width: 0;
   transition: width 0.3s;
 }
@@ -98,6 +126,14 @@ h1 {
   display: flex;
   align-items: center;
   margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+body.dark .nav {
+  background: rgba(36, 36, 36, 0.6);
 }
 
 .nav-links {
@@ -108,17 +144,30 @@ h1 {
 }
 
 .nav a {
-  color: var(--accent-color);
+  position: relative;
+  color: var(--text-color);
   text-decoration: none;
+  padding: 0.25rem 0;
 }
 
-.nav a:hover {
-  text-decoration: underline;
+.nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 2px;
+  background: var(--accent-color);
+  transition: width 0.3s;
+}
+
+.nav a:hover::after,
+.nav a.active::after {
+  width: 100%;
 }
 
 .nav a.active {
   font-weight: 600;
-  text-decoration: underline;
 }
 
 .theme-toggle {

--- a/mcqproject/src/LandingPage.jsx
+++ b/mcqproject/src/LandingPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 function LandingPage() {
   return (
     <div className="card landing">
+      <h2>Welcome</h2>
       <p>Practice multiple choice questions.</p>
       <div className="landing-buttons">
         <Link to="/quiz"><button>Start Quiz</button></Link>

--- a/mcqproject/src/index.css
+++ b/mcqproject/src/index.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;
@@ -7,7 +9,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   --accent-color: #646cff;
-  --bg-color: #f5f5f5;
+  --bg-gradient-start: #f5f5f5;
+  --bg-gradient-end: #e3e3e3;
   --text-color: #213547;
   --card-bg: #fff;
 }
@@ -16,12 +19,14 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: var(--bg-color);
+  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
   color: var(--text-color);
+  transition: background 0.3s, color 0.3s;
 }
 
 body.dark {
-  --bg-color: #1a1a1a;
+  --bg-gradient-start: #1a1a1a;
+  --bg-gradient-end: #2a2a2a;
   --text-color: #f5f5f5;
   --card-bg: #242424;
   --accent-color: #9499ff;
@@ -34,12 +39,18 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: var(--accent-color);
+  background: var(--accent-color);
   color: white;
   cursor: pointer;
-  transition: background-color 0.25s;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: background 0.25s, transform 0.15s;
 }
 
 button:hover {
   filter: brightness(0.9);
+  transform: translateY(-2px);
+}
+
+button:active {
+  transform: translateY(0);
 }


### PR DESCRIPTION
## Summary
- polish layout with Inter fonts, gradient background, and animated buttons
- add animated cards, gradient headings, and frosted navigation bar
- welcome users with a landing page heading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ec6839b4832cb04b91e335f35368