### PR TITLE
Add streak tracking and result sharing

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -195,3 +195,19 @@ body.dark .nav {
 .question-item button {
   margin-right: 0.5rem;
 }
+
+.scoreboard {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-weight: 500;
+}
+
+.achievement {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  text-align: center;
+  border-radius: 4px;
+  background: rgba(255, 215, 0, 0.2);
+}


### PR DESCRIPTION
## Summary
- Track current and best correct-answer streaks with celebratory achievements and audio cues
- Add share button on results screen and persist best streak between sessions
- Style scoreboard and achievement banner for improved feedback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1edc3bfa8832c82144568c9ad8039