### PR TITLE
Add streak tracking, settings, and persistence features

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -195,3 +195,43 @@ body.dark .nav {
 .question-item button {
   margin-right: 0.5rem;
 }
+
+.scoreboard {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-weight: 500;
+}
+
+.achievement {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  text-align: center;
+  border-radius: 4px;
+  background: rgba(255, 215, 0, 0.2);
+}
+
+.timer {
+  text-align: right;
+  font-size: 0.9rem;
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.bookmark {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #ccc;
+}
+
+.bookmark.active {
+  color: var(--accent-color);
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.5rem;
+}

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -1,24 +1,116 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import defaultQuestions from './questions';
+import prepareQuestions from './utils/prepareQuestions';
+import exportCsv from './utils/exportCsv';
+import { loadState, saveState } from './utils/progress';
 
 function Quiz() {
-  const [questions] = useState(() => {
+  const baseQuestions = (() => {
     try {
       const stored = localStorage.getItem('questions');
       const parsed = stored ? JSON.parse(stored) : null;
       if (Array.isArray(parsed) && parsed.length > 0) return parsed;
     } catch {
-      // ignore parse errors and fall back to defaults
+      /* ignore */
     }
     return defaultQuestions;
+  })();
+
+  const settings = {
+    shuffleQs: localStorage.getItem('shuffleQs') === 'true',
+    shuffleOpts: localStorage.getItem('shuffleOpts') === 'true',
+    numQuestions: parseInt(localStorage.getItem('numQuestions'), 10),
+  };
+
+  const [bookmarks, setBookmarks] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('bookmarks')) || [];
+    } catch {
+      return [];
+    }
   });
-  const [current, setCurrent] = useState(0);
+
+  const [showBookmarked, setShowBookmarked] = useState(false);
+
+  const initQuestions = prepareQuestions(
+    showBookmarked ? baseQuestions.filter((q) => bookmarks.includes(q.id)) : baseQuestions,
+    settings.numQuestions,
+    settings.shuffleQs,
+    settings.shuffleOpts
+  );
+
+  const saved = loadState();
+  const [questions, setQuestions] = useState(initQuestions);
+  const [current, setCurrent] = useState(saved.current || 0);
   const [selected, setSelected] = useState(null);
-  const [score, setScore] = useState(0);
+  const [score, setScore] = useState(() => {
+    if (saved.answers) {
+      return saved.answers.reduce(
+        (acc, a, idx) => acc + (initQuestions[idx] && a === initQuestions[idx].answer ? 1 : 0),
+        0
+      );
+    }
+    return 0;
+  });
   const [finished, setFinished] = useState(false);
-  const [answers, setAnswers] = useState([]);
+  const [answers, setAnswers] = useState(saved.answers || []);
+  const [streak, setStreak] = useState(0);
+  const [maxStreak, setMaxStreak] = useState(() => {
+    const stored = parseInt(localStorage.getItem('maxStreak'), 10);
+    return Number.isFinite(stored) ? stored : 0;
+  });
+  const [achievement, setAchievement] = useState('');
+  const audioCtxRef = useRef(null);
+  const [elapsed, setElapsed] = useState(0);
+  const timerRef = useRef(null);
 
   const question = questions[current];
+
+  useEffect(() => {
+    timerRef.current = setInterval(() => setElapsed((e) => e + 1), 1000);
+    return () => clearInterval(timerRef.current);
+  }, []);
+
+  useEffect(() => {
+    saveState({ current, answers, bookmarks });
+  }, [current, answers, bookmarks]);
+
+  useEffect(() => {
+    localStorage.setItem('bookmarks', JSON.stringify(bookmarks));
+  }, [bookmarks]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key >= '1' && e.key <= '4') {
+        const idx = Number(e.key) - 1;
+        if (idx < question.options.length) setSelected(idx);
+      } else if (e.key === 'Enter') {
+        handleNext();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  const playTone = (freq) => {
+    try {
+      if (!audioCtxRef.current) {
+        audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      const ctx = audioCtxRef.current;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.start();
+      gain.gain.setValueAtTime(0.1, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.00001, ctx.currentTime + 0.2);
+      osc.stop(ctx.currentTime + 0.2);
+    } catch {
+      /* ignore audio errors */
+    }
+  };
 
   const handleOption = (index) => {
     setSelected(index);
@@ -28,22 +120,67 @@ function Quiz() {
     if (selected === null) return;
     if (selected === question.answer) {
       setScore(score + 1);
+      const newStreak = streak + 1;
+      setStreak(newStreak);
+      if (newStreak > maxStreak) {
+        setMaxStreak(newStreak);
+        localStorage.setItem('maxStreak', String(newStreak));
+      }
+      if ([3, 5, 10].includes(newStreak)) {
+        const msg = `${newStreak} correct in a row!`;
+        setAchievement(msg);
+        setTimeout(() => setAchievement(''), 3000);
+      }
+      playTone(880);
+    } else {
+      setStreak(0);
+      playTone(440);
     }
-    setAnswers([...answers, selected]);
+    const nextAnswers = [...answers, selected];
+    setAnswers(nextAnswers);
     setSelected(null);
     if (current + 1 < questions.length) {
       setCurrent(current + 1);
     } else {
       setFinished(true);
+      clearInterval(timerRef.current);
     }
   };
 
-  const restart = () => {
+  const restart = (retry = false, useBookmarked = showBookmarked) => {
+    const src = retry
+      ? questions.filter((q, i) => answers[i] !== q.answer)
+      : useBookmarked
+      ? baseQuestions.filter((q) => bookmarks.includes(q.id))
+      : baseQuestions;
+    const prepared = prepareQuestions(
+      src,
+      settings.numQuestions,
+      settings.shuffleQs,
+      settings.shuffleOpts
+    );
+    setQuestions(prepared);
     setCurrent(0);
     setSelected(null);
     setScore(0);
     setFinished(false);
     setAnswers([]);
+    setStreak(0);
+    setAchievement('');
+    setElapsed(0);
+    clearInterval(timerRef.current);
+    timerRef.current = setInterval(() => setElapsed((e) => e + 1), 1000);
+  };
+
+  const share = () => {
+    const text = `I scored ${score}/${questions.length} with a best streak of ${maxStreak} on MCQ Practice!`;
+    if (navigator.share) {
+      navigator.share({ text });
+    } else {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => alert('Result copied to clipboard'));
+    }
   };
 
   if (finished) {
@@ -53,12 +190,14 @@ function Quiz() {
         <p>
           {score} / {questions.length} ({Math.round((score / questions.length) * 100)}%)
         </p>
+        <p>Best streak: {maxStreak}</p>
+        <p>Time: {elapsed}s</p>
         <ul className="review">
           {questions.map((q, idx) => (
             <li key={q.id} className="review-question">
               <p>{q.question}</p>
               <p>
-                Your answer:{' '}
+                Your answer{' '}
                 <span
                   className={
                     answers[idx] === q.answer ? 'correct' : 'incorrect'
@@ -76,6 +215,24 @@ function Quiz() {
           ))}
         </ul>
         <button onClick={restart}>Restart</button>
+        {answers.some((a, idx) => a !== questions[idx].answer) && (
+          <button onClick={() => restart(true)}>Retry Incorrect</button>
+        )}
+        <button onClick={share}>Share</button>
+        <button
+          onClick={() => {
+            const csv = exportCsv(questions, answers, score);
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'results.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
+        >
+          Export CSV
+        </button>
       </div>
     );
   }
@@ -88,8 +245,27 @@ function Quiz() {
           style={{ width: `${(current / questions.length) * 100}%` }}
         ></div>
       </div>
+      <div className="timer">Time: {elapsed}s</div>
+      <div className="scoreboard">
+        <span>Score: {score}</span>
+        <span>Streak: {streak}</span>
+        <span>Best: {maxStreak}</span>
+      </div>
+      {achievement && <div className="achievement">🏆 {achievement}</div>}
       <h2>
-        Question {current + 1} of {questions.length}
+        Question {current + 1} of {questions.length}{' '}
+        <button
+          className={bookmarks.includes(question.id) ? 'bookmark active' : 'bookmark'}
+          onClick={() =>
+            setBookmarks((b) =>
+              b.includes(question.id)
+                ? b.filter((id) => id !== question.id)
+                : [...b, question.id]
+            )
+          }
+        >
+          ★
+        </button>
       </h2>
       <p className="question">{question.question}</p>
       <ul className="options">
@@ -111,8 +287,18 @@ function Quiz() {
       {selected !== null && (
         <p className="explanation">{question.explanation}</p>
       )}
+      <div className="hint">Use 1-4 keys and Enter</div>
       <button className="next" onClick={handleNext} disabled={selected === null}>
         {current + 1 === questions.length ? 'Finish' : 'Next'}
+      </button>
+      <button
+        onClick={() => {
+          const next = !showBookmarked;
+          setShowBookmarked(next);
+          restart(false, next);
+        }}
+      >
+        {showBookmarked ? 'All Questions' : 'Bookmarked Only'}
       </button>
     </div>
   );

--- a/mcqproject/src/Settings.jsx
+++ b/mcqproject/src/Settings.jsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 
 function Settings() {
-  const [numQuestions, setNumQuestions] = useState(3);
+  const [numQuestions, setNumQuestions] = useState(() => {
+    const stored = parseInt(localStorage.getItem('numQuestions'), 10);
+    return Number.isFinite(stored) ? stored : 3;
+  });
   const [shuffleQs, setShuffleQs] = useState(() => localStorage.getItem('shuffleQs') === 'true');
   const [shuffleOpts, setShuffleOpts] = useState(() => localStorage.getItem('shuffleOpts') === 'true');
 
@@ -12,6 +15,10 @@ function Settings() {
   useEffect(() => {
     localStorage.setItem('shuffleOpts', shuffleOpts);
   }, [shuffleOpts]);
+
+  useEffect(() => {
+    localStorage.setItem('numQuestions', numQuestions);
+  }, [numQuestions]);
 
   const count = (() => {
     try {

--- a/mcqproject/src/utils/exportCsv.js
+++ b/mcqproject/src/utils/exportCsv.js
@@ -1,0 +1,11 @@
+export default function exportCsv(questions, answers, score) {
+  const header = 'Question,Your Answer,Correct Answer\n';
+  const rows = questions.map((q, i) => {
+    const your = q.options[answers[i]] ?? '';
+    const correct = q.options[q.answer];
+    const esc = (str) => String(str).replace(/"/g, '""');
+    return `"${esc(q.question)}","${esc(your)}","${esc(correct)}"`;
+  });
+  const footer = `Score,${score}/${questions.length}`;
+  return `${header}${rows.join('\n')}\n${footer}\n`;
+}

--- a/mcqproject/src/utils/prepareQuestions.js
+++ b/mcqproject/src/utils/prepareQuestions.js
@@ -1,0 +1,27 @@
+export function shuffleArray(arr, rand = Math.random) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export default function prepareQuestions(questions, count, shuffleQs, shuffleOpts, rand = Math.random) {
+  let result = [...questions];
+  if (shuffleQs) {
+    result = shuffleArray(result, rand);
+  }
+  if (shuffleOpts) {
+    result = result.map((q) => {
+      const opts = shuffleArray(q.options, rand);
+      const answerText = q.options[q.answer];
+      const newAnswer = opts.indexOf(answerText);
+      return { ...q, options: opts, answer: newAnswer };
+    });
+  }
+  if (Number.isFinite(count) && count > 0 && count < result.length) {
+    result = result.slice(0, count);
+  }
+  return result;
+}

--- a/mcqproject/src/utils/progress.js
+++ b/mcqproject/src/utils/progress.js
@@ -1,0 +1,11 @@
+export function loadState() {
+  try {
+    return JSON.parse(localStorage.getItem('quizState')) || {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveState(state) {
+  localStorage.setItem('quizState', JSON.stringify(state));
+}

--- a/mcqproject/test/exportCsv.test.js
+++ b/mcqproject/test/exportCsv.test.js
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import exportCsv from '../src/utils/exportCsv.js';
+
+const questions = [
+  { question: 'Q1', options: ['a', 'b'], answer: 1 },
+];
+const answers = [1];
+
+test('csv contains headers and score', () => {
+  const csv = exportCsv(questions, answers, 1);
+  assert.ok(csv.startsWith('Question,Your Answer,Correct Answer'));
+  assert.ok(csv.includes('Score,1/1'));
+});

--- a/mcqproject/test/prepareQuestions.test.js
+++ b/mcqproject/test/prepareQuestions.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import prepareQuestions from '../src/utils/prepareQuestions.js';
+
+const sample = [
+  { id: 1, question: 'Q1', options: ['a', 'b'], answer: 0 },
+  { id: 2, question: 'Q2', options: ['c', 'd'], answer: 1 },
+  { id: 3, question: 'Q3', options: ['e', 'f'], answer: 0 },
+];
+
+test('slices to requested count', () => {
+  const res = prepareQuestions(sample, 2, false, false, () => 0.5);
+  assert.strictEqual(res.length, 2);
+  assert.deepStrictEqual(res[0], sample[0]);
+});
+
+test('shuffles questions deterministically', () => {
+  const rand = (() => { let i = 0; const vals = [0.9, 0.1, 0.5]; return () => vals[i++]; })();
+  const res = prepareQuestions(sample, 3, true, false, rand);
+  assert.notDeepStrictEqual(res.map((q) => q.id), sample.map((q) => q.id));
+});
+
+test('shuffles options and updates answer index', () => {
+  const rand = () => 0.2; // forces swap of first two options
+  const res = prepareQuestions(sample.slice(0,1), 1, false, true, rand);
+  assert.deepStrictEqual(res[0].options, ['b', 'a']);
+  assert.strictEqual(res[0].answer, 1);
+});

--- a/mcqproject/test/progress.test.js
+++ b/mcqproject/test/progress.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { loadState, saveState } from '../src/utils/progress.js';
+
+globalThis.localStorage = {
+  store: {},
+  getItem(key) {
+    return this.store[key] || null;
+  },
+  setItem(key, val) {
+    this.store[key] = String(val);
+  },
+  removeItem(key) {
+    delete this.store[key];
+  },
+};
+
+test('stores and loads quiz progress', () => {
+  saveState({ current: 1, answers: [0], bookmarks: [2] });
+  const state = loadState();
+  assert.deepStrictEqual(state, { current: 1, answers: [0], bookmarks: [2] });
+});


### PR DESCRIPTION
## Summary
- Honor stored question count and shuffling preferences while supporting bookmarking and progress restore
- Enable keyboard navigation, session timer, retry-incorrect mode, and CSV result export
- Add utilities and tests for shuffling, CSV generation, and state persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1edc3bfa8832c82144568c9ad8039