### PR TITLE
fix shuffle options toggle

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -7,6 +7,22 @@ import Hotspot from './components/Hotspot.jsx';
 import defaultQuestions from './questions';
 import { RepeatEngine } from './repeat/engine';
 
+// Shuffle helpers need to be defined before they're used in buildQuestions.
+// Previously these were declared later in the component which meant enabling
+// shuffle options attempted to invoke an uninitialized function, triggering a
+// runtime ReferenceError and rendering a blank screen.
+function shuffleArray(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function shuffleCopy(arr) {
+  return shuffleArray([...arr]);
+}
+
 function Quiz() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
@@ -227,15 +243,6 @@ function Quiz() {
       if (feedbackTrigger === 'onSelect' && mode !== 'test') setRevealed(true);
     }
   };
-
-  const shuffleArray = (arr) => {
-    for (let i = arr.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [arr[i], arr[j]] = [arr[j], arr[i]];
-    }
-    return arr;
-  };
-  const shuffleCopy = (arr) => shuffleArray([...arr]);
 
   const saveSession = (nextState = {}) => {
     const payload = {

--- a/mcqproject/src/Settings.jsx
+++ b/mcqproject/src/Settings.jsx
@@ -20,13 +20,6 @@ function Settings() {
   useEffect(() => {
     localStorage.setItem('shuffleOpts', shuffleOpts);
   }, [shuffleOpts]);
-  // Temporarily disable Shuffle options to avoid rendering issues; force-off in storage
-  useEffect(() => {
-    try {
-      localStorage.setItem('shuffleOpts', 'false');
-      setShuffleOpts(false);
-    } catch {}
-  }, []);
 
   useEffect(() => {
     localStorage.setItem('instantReveal', instantReveal);
@@ -78,8 +71,16 @@ function Settings() {
               />
             </label>
             <label className="toggle"><input type="checkbox" checked={shuffleQs} onChange={(e)=>{ setShuffleQs(e.target.checked); toast('Shuffle questions updated'); }} /> Shuffle questions</label>
-            <label className="toggle" title="Temporarily disabled while we improve stability">
-              <input type="checkbox" checked={false} disabled /> Shuffle options (coming soon)
+            <label className="toggle">
+              <input
+                type="checkbox"
+                checked={shuffleOpts}
+                onChange={(e) => {
+                  setShuffleOpts(e.target.checked);
+                  toast('Shuffle options updated');
+                }}
+              />{' '}
+              Shuffle options
             </label>
             <label>Feedback timing
               <select value={feedbackTrigger} onChange={(e)=>{ setFeedbackTrigger(e.target.value); toast('Feedback timing updated'); }} style={{marginLeft:8}}>


### PR DESCRIPTION
## Summary
- prevent quiz from crashing when shuffling answer options by defining shuffle helpers before use
- restore Shuffle Options setting so answers can be randomized again

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty, unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c7835bc8832ca913ac247ec53538