### PR TITLE
Improve service worker registration and cache handling

### DIFF
--- a/mcqproject/public/sw.js
+++ b/mcqproject/public/sw.js
@@ -1,22 +1,53 @@
-const CACHE = 'mcq-cache-v1';
+const CACHE = `mcq-cache-${Date.now()}`;
 const ASSETS = [
   '/',
   '/index.html',
 ];
+
 self.addEventListener('install', (e) => {
+  self.skipWaiting();
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(ASSETS)));
 });
+
 self.addEventListener('activate', (e) => {
-  e.waitUntil(caches.keys().then((keys) => Promise.all(keys.filter(k=>k!==CACHE).map((k)=>caches.delete(k)))));
+  e.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))
+      )
+      .then(() => self.clients.claim())
+  );
 });
+
 self.addEventListener('fetch', (e) => {
   const req = e.request;
+  if (req.mode === 'navigate') {
+    e.respondWith(
+      fetch(req)
+        .then((res) => {
+          const copy = res.clone();
+          caches.open(CACHE).then((c) => c.put(req, copy));
+          return res;
+        })
+        .catch(() => caches.match(req))
+    );
+    return;
+  }
   e.respondWith(
-    caches.match(req).then((hit) => hit || fetch(req).then((res) => {
-      const copy = res.clone();
-      caches.open(CACHE).then((c) => c.put(req, copy));
-      return res;
-    }).catch(()=>hit))
+    caches
+      .match(req)
+      .then(
+        (hit) =>
+          hit ||
+          fetch(req)
+            .then((res) => {
+              const copy = res.clone();
+              caches.open(CACHE).then((c) => c.put(req, copy));
+              return res;
+            })
+            .catch(() => hit)
+      )
   );
 });
 

--- a/mcqproject/src/main.jsx
+++ b/mcqproject/src/main.jsx
@@ -8,10 +8,7 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>,
 )
-
-// PWA: basic service worker registration (works in build/preview)
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    try { navigator.serviceWorker.register('/sw.js'); } catch {}
-  });
+// PWA: basic service worker registration (production only)
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => navigator.serviceWorker.register('/sw.js'));
 }


### PR DESCRIPTION
## Summary
- Register service worker only in production
- Use build-specific cache name and immediate activation logic
- Add network-first handling for navigation requests

## Testing
- `npm test`
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c9c13f4c832c934cf6a4b28644a4