### PR TITLE
feat: allow custom keyboard shortcuts

### DIFF
--- a/mcqproject/src/App.jsx
+++ b/mcqproject/src/App.jsx
@@ -9,6 +9,7 @@ import Review from './Review.jsx';
 import RepeatBuilder from './RepeatBuilder.jsx';
 import Toaster from './components/Toaster.jsx';
 import HelpOverlay from './components/HelpOverlay.jsx';
+import { loadKeymap } from './utils/keymap.js';
 
 function ModeBadge() {
   const location = useLocation();
@@ -39,8 +40,9 @@ function App() {
 
   useEffect(() => {
     const onKey = (e) => {
-      if (e.key === '?') setShowHelp(true);
-      if (e.key === 'Escape') setShowHelp(false);
+      const keymap = loadKeymap();
+      if (e.key === keymap.help) setShowHelp(true);
+      if (e.key === keymap.close) setShowHelp(false);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -6,6 +6,7 @@ import { ensureKatex, renderMDKaTeX } from './utils/katex';
 import Hotspot from './components/Hotspot.jsx';
 import defaultQuestions from './questions';
 import { RepeatEngine } from './repeat/engine';
+import { loadKeymap } from './utils/keymap.js';
 
 // Shuffle helpers need to be defined before they're used in buildQuestions.
 // Previously these were declared later in the component which meant enabling
@@ -379,30 +380,31 @@ function Quiz() {
     toast(value ? 'Note saved' : 'Note cleared');
   };
 
-  // Keyboard shortcuts: 1–9 select/toggle, Enter submit/next
+  // Keyboard shortcuts are customizable via Settings
   useEffect(() => {
     const onKey = (e) => {
       if (!question) return;
-      if (['INPUT','TEXTAREA'].includes(e.target.tagName)) return;
-      const num = parseInt(e.key, 10);
+      if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+      const keymap = loadKeymap();
       const optsLen = Array.isArray(question.options) ? question.options.length : 0;
-      const order = (Array.isArray(question._order) && question._order.length===optsLen && question._order.every(i => Number.isInteger(i) && i>=0 && i<optsLen))
+      const order = (Array.isArray(question._order) && question._order.length === optsLen && question._order.every(i => Number.isInteger(i) && i >= 0 && i < optsLen))
         ? question._order
         : [...Array(optsLen).keys()];
-      if (num >= 1 && num <= Math.min(9, optsLen)) {
-        const optIdx = order[num - 1];
+      const idx = keymap.options.indexOf(e.key);
+      if (idx !== -1 && idx < optsLen) {
+        const optIdx = order[idx];
         handleOption(optIdx);
-      } else if (e.key === 'Enter') {
+      } else if (e.key === keymap.next) {
         handleNext();
-      } else if (e.key === 'ArrowRight') {
-        if (selected.length>0) handleNext();
-      } else if (e.key === 'ArrowLeft') {
-        if (current>0) { setCurrent(current-1); setSelected([]); }
+      } else if (e.key === keymap.nextAlt) {
+        if (selected.length > 0) handleNext();
+      } else if (e.key === keymap.prev) {
+        if (current > 0) { setCurrent(current - 1); setSelected([]); }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [question, selected, handleNext]);
+  }, [question, selected, handleNext, current]);
 
   const restart = () => {
     setCurrent(0);

--- a/mcqproject/src/Settings.jsx
+++ b/mcqproject/src/Settings.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { toast } from './utils/toast.js';
 import { loadRepeatSettings, saveRepeatSettings } from './repeat/settings';
+import { loadKeymap, saveKeymap, defaultKeymap } from './utils/keymap.js';
 
 function Settings() {
   const [numQuestions, setNumQuestions] = useState(3);
@@ -12,6 +13,7 @@ function Settings() {
   const [testNoChange, setTestNoChange] = useState(() => localStorage.getItem('testNoChange') === 'true');
   const [partialCredit, setPartialCredit] = useState(() => localStorage.getItem('partialCredit') === 'true');
   const [repeatCfg, setRepeatCfg] = useState(() => loadRepeatSettings());
+  const [keymap, setKeymap] = useState(() => loadKeymap());
 
   useEffect(() => {
     localStorage.setItem('shuffleQs', shuffleQs);
@@ -37,6 +39,7 @@ function Settings() {
     localStorage.setItem('testNoChange', testNoChange);
   }, [testNoChange]);
   useEffect(() => { saveRepeatSettings(repeatCfg); }, [repeatCfg]);
+  useEffect(() => { saveKeymap(keymap); }, [keymap]);
 
   const count = (() => {
     try {
@@ -127,8 +130,91 @@ function Settings() {
           <div className="chips" style={{marginTop:8}}>
             <label className="toggle"><input type="checkbox" checked={repeatCfg.strictMultiAnswer} onChange={(e)=>setRepeatCfg({...repeatCfg, strictMultiAnswer:e.target.checked})} /> Strict multi-answer</label>
             <label className="toggle"><input type="checkbox" checked={repeatCfg.partialCreditMode} onChange={(e)=>setRepeatCfg({...repeatCfg, partialCreditMode:e.target.checked})} /> Partial credit</label>
-            <label className="toggle"><input type="checkbox" checked={repeatCfg.autoRevealExplanationOnError} onChange={(e)=>setRepeatCfg({...repeatCfg, autoRevealExplanationOnError:e.target.checked})} /> Auto-show explanation on wrong</label>
+          <label className="toggle"><input type="checkbox" checked={repeatCfg.autoRevealExplanationOnError} onChange={(e)=>setRepeatCfg({...repeatCfg, autoRevealExplanationOnError:e.target.checked})} /> Auto-show explanation on wrong</label>
           </div>
+        </div>
+        <div className="card" style={{padding:'12px'}}>
+          <h3 style={{marginTop:0}}>Keyboard</h3>
+          <p className="muted" style={{marginTop:-6}}>Click a field then press a key.</p>
+          <div style={{display:'grid',gridTemplateColumns:'repeat(3,1fr)',gap:'8px'}}>
+            {keymap.options.map((k, i) => (
+              <label key={i}>Option {i + 1}
+                <input
+                  type="text"
+                  value={k}
+                  onKeyDown={(e) => {
+                    e.preventDefault();
+                    const opts = [...keymap.options];
+                    opts[i] = e.key;
+                    setKeymap({ ...keymap, options: opts });
+                    toast('Shortcut updated');
+                  }}
+                  onChange={() => {}}
+                />
+              </label>
+            ))}
+            <label>Next
+              <input
+                type="text"
+                value={keymap.next}
+                onKeyDown={(e) => {
+                  e.preventDefault();
+                  setKeymap({ ...keymap, next: e.key });
+                  toast('Shortcut updated');
+                }}
+                onChange={() => {}}
+              />
+            </label>
+            <label>Prev
+              <input
+                type="text"
+                value={keymap.prev}
+                onKeyDown={(e) => {
+                  e.preventDefault();
+                  setKeymap({ ...keymap, prev: e.key });
+                  toast('Shortcut updated');
+                }}
+                onChange={() => {}}
+              />
+            </label>
+            <label>Alt Next
+              <input
+                type="text"
+                value={keymap.nextAlt}
+                onKeyDown={(e) => {
+                  e.preventDefault();
+                  setKeymap({ ...keymap, nextAlt: e.key });
+                  toast('Shortcut updated');
+                }}
+                onChange={() => {}}
+              />
+            </label>
+            <label>Help
+              <input
+                type="text"
+                value={keymap.help}
+                onKeyDown={(e) => {
+                  e.preventDefault();
+                  setKeymap({ ...keymap, help: e.key });
+                  toast('Shortcut updated');
+                }}
+                onChange={() => {}}
+              />
+            </label>
+            <label>Close
+              <input
+                type="text"
+                value={keymap.close}
+                onKeyDown={(e) => {
+                  e.preventDefault();
+                  setKeymap({ ...keymap, close: e.key });
+                  toast('Shortcut updated');
+                }}
+                onChange={() => {}}
+              />
+            </label>
+          </div>
+          <button className="btn-ghost" style={{marginTop:8}} onClick={() => { setKeymap(defaultKeymap); toast('Shortcuts reset'); }}>Reset Defaults</button>
         </div>
       </div>
     </div>

--- a/mcqproject/src/components/HelpOverlay.jsx
+++ b/mcqproject/src/components/HelpOverlay.jsx
@@ -1,18 +1,18 @@
 import Modal from './Modal.jsx';
+import { loadKeymap } from '../utils/keymap.js';
 
 export default function HelpOverlay({ open, onClose }) {
+  const keymap = loadKeymap();
   return (
     <Modal open={open} onClose={onClose} title="Keyboard Shortcuts"
       footer={[<button key="close" className="btn-ghost" onClick={onClose}>Close</button>]}
     >
       <ul style={{listStyle:'none',padding:0,margin:0,display:'grid',gridTemplateColumns:'1fr 1fr',gap:'8px'}}>
-        <li><span className="kbd">1–9</span> select/toggle option</li>
-        <li><span className="kbd">Enter</span> submit / next</li>
-        <li><span className="kbd">← / →</span> navigate</li>
-        <li><span className="kbd">/</span> focus search</li>
-        <li><span className="kbd">b</span> bookmark</li>
-        <li><span className="kbd">?</span> help overlay</li>
-        <li><span className="kbd">Esc</span> close modals</li>
+        <li><span className="kbd">{keymap.options.join(' ')}</span> select/toggle option</li>
+        <li><span className="kbd">{keymap.next}</span> submit / next</li>
+        <li><span className="kbd">{keymap.prev} / {keymap.nextAlt}</span> navigate</li>
+        <li><span className="kbd">{keymap.help}</span> help overlay</li>
+        <li><span className="kbd">{keymap.close}</span> close modals</li>
       </ul>
     </Modal>
   );

--- a/mcqproject/src/utils/keymap.js
+++ b/mcqproject/src/utils/keymap.js
@@ -1,0 +1,30 @@
+export const defaultKeymap = {
+  options: ['1','2','3','4','5','6','7','8','9'],
+  next: 'Enter',
+  nextAlt: 'ArrowRight',
+  prev: 'ArrowLeft',
+  help: '?',
+  close: 'Escape'
+};
+
+export function loadKeymap() {
+  try {
+    const raw = JSON.parse(localStorage.getItem('keymap'));
+    if (raw && typeof raw === 'object') {
+      return {
+        ...defaultKeymap,
+        ...raw,
+        options: Array.isArray(raw.options) && raw.options.length
+          ? raw.options
+          : defaultKeymap.options
+      };
+    }
+  } catch {
+    // ignore
+  }
+  return { ...defaultKeymap };
+}
+
+export function saveKeymap(map) {
+  localStorage.setItem('keymap', JSON.stringify(map));
+}


### PR DESCRIPTION
## Summary
- add keymap utility and persistent settings for shortcut customization
- wire quiz and app navigation to user-defined keymap
- expose shortcut mapping UI and reset option in settings
- show active bindings in help overlay

## Testing
- `npm test`
- `npm run lint` *(fails: idx is defined but never used, i is defined but never used, empty block statement, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cd32ef0c832c991ce7c8306bad37