### PR TITLE
fix: retry only incorrect questions

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -730,7 +730,16 @@ function exportResultsCSV(questions, answers){
 
 function retryIncorrect(questions, answers, setCurrent, setFinished){
   const incorrectIdx = questions.map((q,i)=>{
-    const corr=Array.isArray(q.answers)?q.answers:Array.isArray(q.answer)?q.answer:[q.answer];
+    // Normalize correct answers from various question shapes
+    const corr = Array.isArray(q.correct)
+      ? q.correct
+      : Array.isArray(q.answers)
+      ? q.answers
+      : Array.isArray(q.answer)
+      ? q.answer
+      : Number.isFinite(q.answer)
+      ? [q.answer]
+      : [];
     const sel=new Set(answers[i]||[]); const cor=new Set(corr);
     const ok= sel.size===cor.size && [...cor].every(n=>sel.has(n));
     return ok?null:i;


### PR DESCRIPTION
## Summary
- normalize correct answer fields in retry logic to handle `correct`, `answers`, or `answer`

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ceae7e54832c88ce30ad1a04f9ea