### PR TITLE
Enable configurable adaptive repeat mode

### DIFF
--- a/mcqproject/src/App.jsx
+++ b/mcqproject/src/App.jsx
@@ -61,7 +61,7 @@ function App() {
               Home
             </NavLink>
             <NavLink to="/quiz">Quiz</NavLink>
-            <NavLink to="/quiz?mode=repeat&source=lastWrong">Repeat</NavLink>
+            <NavLink to="/repeat">Repeat</NavLink>
             <NavLink to="/review">Review</NavLink>
             <NavLink to="/review?bookmarks=1">Bookmarks</NavLink>
             <NavLink to="/settings">Settings</NavLink>

--- a/mcqproject/src/LandingPage.jsx
+++ b/mcqproject/src/LandingPage.jsx
@@ -40,6 +40,10 @@ function LandingPage() {
           <strong>Challenge</strong>
           <span className="muted">Points, speed bonus</span>
         </Link>
+        <Link to="/repeat" className="menu-card">
+          <strong>Repeat</strong>
+          <span className="muted">Adaptive drills with mastery</span>
+        </Link>
         <Link to="/review" className="menu-card">
           <strong>Review</strong>
           <span className="muted">Browse, search, filter, retry incorrect</span>

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -61,6 +61,7 @@ function Quiz() {
       const url = new URL(window.location.href);
       const setId = url.searchParams.get('setId');
       const hard = url.searchParams.get('hard') === 'true';
+      const tagsParam = url.searchParams.get('tags');
       const countParam = parseInt(url.searchParams.get('count'), 10);
       if (setId === 'bookmarks') {
         try {
@@ -77,6 +78,12 @@ function Quiz() {
             arr = arr.filter((q) => idSet.has(q.id));
           }
         } catch { /* ignore */ }
+      }
+      if (tagsParam) {
+        const tags = tagsParam.split(',').map((t) => t.trim()).filter(Boolean);
+        if (tags.length) {
+          arr = arr.filter((q) => Array.isArray(q.tags) && q.tags.some((t) => tags.includes(t)));
+        }
       }
       if (hard) {
         try {
@@ -163,6 +170,7 @@ function Quiz() {
       try {
         const url = new URL(window.location.href);
         const source = url.searchParams.get('source');
+        const tagsParam = url.searchParams.get('tags');
         if (source === 'lastWrong') {
           const sess = JSON.parse(localStorage.getItem('mcqSession')||'{}');
           const wrongIdx = (sess.results||[]).filter(r=>!r.isCorrect).map(r=>r.index||0);
@@ -172,6 +180,9 @@ function Quiz() {
           const stats = JSON.parse(localStorage.getItem('repeatStats')||'{}');
           pool = questions.filter(q => (stats[q.id]?.wrong||0) > 0).map(q=>q.id);
           setRepeatSourceLabel('All-time wrong');
+        } else if (source === 'byTags') {
+          pool = questions.map(q=>q.id);
+          setRepeatSourceLabel(tagsParam ? `Tags: ${tagsParam}` : 'Selected tags');
         } else {
           pool = questions.map(q=>q.id);
           setRepeatSourceLabel('Entire pool');


### PR DESCRIPTION
## Summary
- Route Repeat nav and landing links to builder for manual set and count selection
- Allow filtering questions by tags in repeat mode and show tag labels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e59b30bc832c96b0b099e9b2bb52