### PR TITLE
Clarify repeat mode mastery settings

### DIFF
--- a/mcqproject/src/RepeatBuilder.jsx
+++ b/mcqproject/src/RepeatBuilder.jsx
@@ -71,27 +71,32 @@ export default function RepeatBuilder() {
           </div>
           <div className="card" style={{padding:'12px'}}>
             <h3 style={{marginTop:0}}>Mastery & Cooldown</h3>
+            <p className="soft-hint" style={{marginTop:-6}}>Control how questions are mastered and when they return.</p>
             <div className="grid-2">
               <label>Mastery type
                 <select value={cfg.masteryType} onChange={(e)=>setCfg({...cfg, masteryType:e.target.value})}>
                   <option value="consecutive">Consecutive</option>
                   <option value="ratio">3 of last 4</option>
                 </select>
+                <small className="soft-hint">Consecutive requires a streak; ratio looks at the last four attempts.</small>
               </label>
               <label>Target
                 <input type="number" min="1" value={cfg.masteryTarget} onChange={(e)=>setCfg({...cfg, masteryTarget:parseInt(e.target.value,10)||1})} />
+                <small className="soft-hint">Required correct answers (e.g. 2 in a row or 3 of last 4).</small>
               </label>
               <label>Cooldown (s)
                 <input type="number" min="0" value={cfg.cooldownSeconds} onChange={(e)=>setCfg({...cfg, cooldownSeconds:parseInt(e.target.value,10)||0})} />
+                <small className="soft-hint">Minimum seconds before the question can appear again.</small>
               </label>
               <label>Leech threshold
                 <input type="number" min="1" value={cfg.leechThreshold} onChange={(e)=>setCfg({...cfg, leechThreshold:parseInt(e.target.value,10)||1})} />
+                <small className="soft-hint">Wrong attempts before a question is flagged as a leech.</small>
               </label>
             </div>
             <div className="chips" style={{marginTop:8}}>
-              <label className="toggle"><input type="checkbox" checked={cfg.strictMultiAnswer} onChange={(e)=>setCfg({...cfg, strictMultiAnswer:e.target.checked})} /> Strict multi-answer</label>
-              <label className="toggle"><input type="checkbox" checked={cfg.partialCreditMode} onChange={(e)=>setCfg({...cfg, partialCreditMode:e.target.checked})} /> Partial credit</label>
-              <label className="toggle"><input type="checkbox" checked={cfg.autoRevealExplanationOnError} onChange={(e)=>setCfg({...cfg, autoRevealExplanationOnError:e.target.checked})} /> Auto-show explanation on wrong</label>
+              <label className="toggle" title="Must select all correct options. Extra choices count as wrong"><input type="checkbox" checked={cfg.strictMultiAnswer} onChange={(e)=>setCfg({...cfg, strictMultiAnswer:e.target.checked})} /> Strict multi-answer</label>
+              <label className="toggle" title="Award partial points for multi-answer questions"><input type="checkbox" checked={cfg.partialCreditMode} onChange={(e)=>setCfg({...cfg, partialCreditMode:e.target.checked})} /> Partial credit</label>
+              <label className="toggle" title="Automatically show explanation after a wrong answer"><input type="checkbox" checked={cfg.autoRevealExplanationOnError} onChange={(e)=>setCfg({...cfg, autoRevealExplanationOnError:e.target.checked})} /> Auto-show explanation on wrong</label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add help text explaining mastery type, target, cooldown, and leech threshold
- add tooltips to mastery options for multi-answer, partial credit, and auto explanations

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c3e7a2b69c832ca3fbb29fcb0a2719