### PR TITLE
feat: enable quick question edits during quiz

### DIFF
--- a/mcqproject/README_APP.md
+++ b/mcqproject/README_APP.md
@@ -10,6 +10,7 @@ Key features
 - Modes: Practice (instant feedback), Test (no feedback until end), Challenge (points/streaks), Review (browse/filter).
 - Multi-answer support with strict or Partial Credit mode (Settings).
 - Bookmarks (⭐) and Notes (📝) per question; persisted to localStorage.
+- Quick edit (✏️) opens the current question in the Questions editor.
 - Search & tag filters in Review, “Retry Incorrect Only”.
 - Results: score %, streaks, basic badges, export CSV.
 - Theme: Light/Dark with system preference; responsive layout.

--- a/mcqproject/src/Import.jsx
+++ b/mcqproject/src/Import.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import Modal from './components/Modal.jsx';
 import { toast } from './utils/toast.js';
 
 function ImportQuestions() {
+  const location = useLocation();
   const [questions, setQuestions] = useState([]);
   const [error, setError] = useState('');
   const [editingId, setEditingId] = useState(null);
@@ -147,6 +149,15 @@ function ImportQuestions() {
     });
     setActiveTab('editor');
   };
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const editId = params.get('edit');
+    if (editId && !editingId) {
+      const q = questions.find((x) => String(x.id) === String(editId));
+      if (q) startEdit(q);
+    }
+  }, [location.search, questions, editingId]);
 
   const importFromText = () => {
     try {

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -107,6 +107,15 @@ function Quiz() {
   };
 
   const [questions, setQuestions] = useState(() => buildQuestions());
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === 'questions') {
+        setQuestions(buildQuestions());
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
   const engineRef = useRef(null);
   const byIdRef = useRef(new Map());
   const [repeatAttempted, setRepeatAttempted] = useState(0);
@@ -455,6 +464,14 @@ function Quiz() {
     toast(value ? 'Note saved' : 'Note cleared');
   };
 
+  const editQuestion = () => {
+    const id = question?.id;
+    if (!id) return;
+    const url = new URL('/import', window.location.origin);
+    url.searchParams.set('edit', id);
+    window.open(url.toString(), '_blank');
+  };
+
   // Keyboard shortcuts are customizable via Settings
   useEffect(() => {
     const onKey = (e) => {
@@ -733,32 +750,41 @@ function Quiz() {
       </div>
       {achievement && <div className="achievement">🏆 {achievement}</div>}
       {!noQuestions && (
-      <h2>
-        {mode==='repeat' ? (
-          <>Item {repeatAttempted + 1} of {Math.max(1, repeatDynamicTotal)}</>
-        ) : (
-          <>Question {current + 1} of {questions.length}</>
+        <h2>
+          {mode==='repeat' ? (
+            <>Item {repeatAttempted + 1} of {Math.max(1, repeatDynamicTotal)}</>
+          ) : (
+            <>Question {current + 1} of {questions.length}</>
+          )}
+          <button
+            type="button"
+            onClick={toggleBookmark}
+            className="icon-btn"
+            style={{ marginLeft: '0.5rem' }}
+            title="Bookmark"
+          >
+            {bookmarks.has(question.id) ? '★' : '☆'}
+          </button>
+          <button
+            type="button"
+            onClick={addNote}
+            className="icon-btn"
+            style={{ marginLeft: '0.25rem' }}
+            title="Add note"
+          >
+            📝
+          </button>
+          <button
+            type="button"
+            onClick={editQuestion}
+            className="icon-btn"
+            style={{ marginLeft: '0.25rem' }}
+            title="Edit question"
+          >
+            ✏️
+          </button>
+        </h2>
         )}
-        <button
-          type="button"
-          onClick={toggleBookmark}
-          className="icon-btn"
-          style={{ marginLeft: '0.5rem' }}
-          title="Bookmark"
-        >
-          {bookmarks.has(question.id) ? '★' : '☆'}
-        </button>
-        <button
-          type="button"
-          onClick={addNote}
-          className="icon-btn"
-          style={{ marginLeft: '0.25rem' }}
-          title="Add note"
-        >
-          📝
-        </button>
-      </h2>
-      )}
       {!noQuestions && isMulti && (
         <div className="badge" aria-hidden="true" style={{display:'inline-block',marginBottom:'6px'}}>Select ALL that apply · Choose {correct.length}</div>
       )}


### PR DESCRIPTION
## Summary
- add edit icon in quiz to open current question in Questions editor
- support `?edit=id` param in editor for direct navigation
- refresh quiz questions when storage updates and document the new shortcut

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4213882f0832c8be2e212de8db966