### PR TITLE
Preserve question line breaks in quiz view

### DIFF
--- a/mcqproject/src/utils/katex.js
+++ b/mcqproject/src/utils/katex.js
@@ -46,6 +46,6 @@ export function renderMDKaTeX(text = '') {
     }
     html = parts.join('');
   }
-  return html;
+  return html.replace(/\r?\n/g, '<br />');
 }
 


### PR DESCRIPTION
## Summary
- Ensure Markdown+KaTeX renderer keeps newline spacing by converting `\r?\n` to `<br />`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c422e38a88832cb8d67831ddfe5495