### PR TITLE
feat: enhance question import and filtering

### DIFF
--- a/mcqproject/src/utils/id.js
+++ b/mcqproject/src/utils/id.js
@@ -1,0 +1,5 @@
+let counter = Date.now();
+export function generateId() {
+  counter += 1;
+  return counter;
+}


### PR DESCRIPTION
## Summary
- add unique ID generator and assign imported questions to sets
- precompute question assignments for faster filtering
- prompt to assign sets when importing JSON or pasting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c549fec89c832c90b3602ca3d0308e