### PR TITLE
Fix question import duplicates and stabilize modal

### DIFF
--- a/mcqproject/src/components/Modal.jsx
+++ b/mcqproject/src/components/Modal.jsx
@@ -1,13 +1,26 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
 export default function Modal({ open, onClose, title, children, footer }) {
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   if (!open) return null;
-  return (
+  return createPortal(
     <div className="modal" role="dialog" aria-modal="true" onClick={onClose}>
       <div className="box" onClick={(e) => e.stopPropagation()} style={{ minWidth: 320 }}>
         {title && <h3 style={{ marginTop: 0 }}>{title}</h3>}
         <div>{children}</div>
         {footer && <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>{footer}</div>}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure imported questions get unique IDs and merge once into selected set
- refresh state and toast with unassigned details after import
- render modal via portal with body scroll lock

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c551410bdc832c8bf10ef0475ce3c6