### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,15 @@ th.sortable.desc:after{content:'\25BE'}
   main{grid-template-columns:1fr}
   aside#sidebar{order:2}
 }
+@media (max-width:600px){
+  header{grid-template-columns:1fr auto;padding:8px 12px;}
+  .shell-right{flex-wrap:wrap;gap:4px;}
+  .drawer{width:100%;right:-100%;}
+  .drawer.open{right:0;}
+  .modal .box{width:90%;max-width:none;}
+  .btn,.icon-btn,input,select{padding:10px 14px;}
+  footer{flex-direction:column;align-items:stretch;}
+}
 @media (prefers-reduced-motion: reduce){
   *{transition:none!important}
 }

--- a/mcq.html
+++ b/mcq.html
@@ -20,7 +20,13 @@
   #controls{margin-top:15px;display:flex;gap:10px;}
   #result{text-align:center;}
   .hidden{display:none;}
-  @media(max-width:600px){body{padding:10px;}}
+  @media(max-width:600px){
+    body{padding:10px;}
+    #controls{flex-direction:column;width:100%;}
+    #controls button{width:100%;}
+    .option{padding:12px;}
+    #fileInput{margin-bottom:12px;width:100%;}
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Tweak main UI styles to better fit small screens: compact header, wrapping nav items, full-width drawer, and touch-friendly controls.
- Enhance legacy quiz page with stacked controls, wider buttons, and mobile padding.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/MCQproject/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c555f75bb4832c881d78ed1de5e6e2