### PR TITLE
Load question JSON files as separate default sets

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -243,3 +243,25 @@ body.dark .nav {
   border-radius: 4px;
   background: rgba(255, 215, 0, 0.2);
 }
+
+/* Mobile tweaks for navigation and layout */
+@media (max-width: 600px) {
+  .app {
+    padding: 0.75rem;
+  }
+  .nav {
+    grid-template-columns: 1fr;
+    row-gap: 0.5rem;
+  }
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+  .mode-and-progress {
+    justify-content: center;
+  }
+  .top-progress {
+    width: 100%;
+  }
+}

--- a/mcqproject/src/main.jsx
+++ b/mcqproject/src/main.jsx
@@ -2,6 +2,35 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { set1, set2, set3, set4, set5 } from './questions.js';
+
+// On first load, populate localStorage with the bundled question sets so
+// users have a ready-to-use library without needing to import anything.
+const defaultSets = { set1, set2, set3, set4, set5 };
+const allQuestions = [...set1, ...set2, ...set3, ...set4, ...set5];
+const LS_Q_KEY = 'questions';
+const LS_S_KEY = 'sets';
+
+if (!localStorage.getItem(LS_Q_KEY)) {
+  try {
+    localStorage.setItem(LS_Q_KEY, JSON.stringify(allQuestions));
+  } catch {
+    // Ignore write errors (e.g., storage disabled)
+  }
+}
+
+if (!localStorage.getItem(LS_S_KEY)) {
+  try {
+    const sets = Object.entries(defaultSets).map(([name, arr]) => ({
+      id: name,
+      name,
+      questionIds: arr.map((q) => q.id),
+    }));
+    localStorage.setItem(LS_S_KEY, JSON.stringify(sets));
+  } catch {
+    // Ignore write errors
+  }
+}
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/mcqproject/src/questions.js
+++ b/mcqproject/src/questions.js
@@ -1,51 +1,9 @@
-const questions = [
-  {
-    id: 1,
-    question: 'What is the capital of France?',
-    options: ['Berlin', 'Paris', 'Rome', 'Madrid'],
-    answer: 1,
-    explanation: 'Paris is the capital and most populous city of France.',
-    tags: ['geography'],
-  },
-  {
-    id: 2,
-    question: 'Which planet is known as the Red Planet?',
-    options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
-    answer: 1,
-    explanation: 'Mars is called the Red Planet due to its reddish appearance.',
-    tags: ['space'],
-  },
-  {
-    id: 3,
-    question: 'What is 2 + 2?',
-    options: ['3', '4', '5', '6'],
-    answer: 1,
-    explanation: 'Adding 2 and 2 gives 4.',
-    tags: ['math'],
-  },
-  // Multi-answer sample
-  {
-    id: 4,
-    question: 'Which are prime numbers?',
-    options: ['2', '3', '4', '5'],
-    answer: [0,1,3],
-    explanation: '2, 3, and 5 are primes.',
-    tags: ['math'],
-  },
-  // Hotspot sample (scaffold)
-  {
-    id: 5,
-    type: 'hotspot',
-    question: 'Click the highlighted area of the logo',
-    media: {
-      src: 'https://dummyimage.com/600x300/222/fff.png&text=Hotspot+Demo',
-      zones: [ {x: 20, y: 30, w: 20, h: 25} ],
-    },
-    options: ['Zone A'],
-    answer: [0],
-    explanation: 'The box on the left is the target zone.',
-    tags: ['hotspot'],
-  },
-];
+import set1 from './assets/_MConverter.eu_1-30.json' with { type: 'json' };
+import set2 from './assets/_MConverter.eu_31-60.json' with { type: 'json' };
+import set3 from './assets/_MConverter.eu_61-90.json' with { type: 'json' };
+import set4 from './assets/_MConverter.eu_91-120.json' with { type: 'json' };
+import set5 from './assets/_MConverter.eu_youtube50.json' with { type: 'json' };
 
-export default questions;
+// Export each question file as its own default set.
+export { set1, set2, set3, set4, set5 };
+

--- a/mcqproject/test/questions.test.js
+++ b/mcqproject/test/questions.test.js
@@ -1,15 +1,22 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import questions from '../src/questions.js';
+import { set1, set2, set3, set4, set5 } from '../src/questions.js';
 
-test('questions array has expected length', () => {
-  assert.ok(Array.isArray(questions));
-  assert.strictEqual(questions.length, 5);
+const allSets = { set1, set2, set3, set4, set5 };
+
+test('default sets have expected lengths', () => {
+  assert.strictEqual(set1.length, 30);
+  assert.strictEqual(set2.length, 28);
+  assert.strictEqual(set3.length, 29);
+  assert.strictEqual(set4.length, 26);
+  assert.strictEqual(set5.length, 50);
 });
 
 test('each question includes an explanation', () => {
-  for (const q of questions) {
-    assert.strictEqual(typeof q.explanation, 'string');
-    assert.notStrictEqual(q.explanation.length, 0);
+  for (const set of Object.values(allSets)) {
+    for (const q of set) {
+      assert.strictEqual(typeof q.explanation, 'string');
+      assert.notStrictEqual(q.explanation.length, 0);
+    }
   }
 });


### PR DESCRIPTION
## Summary
- Expose bundled question JSON files as individual sets (set1–set5)
- Seed localStorage with combined questions and set metadata on first load
- Adjust tests to verify each default set and explanations

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c558451e4c832c805626620dca5f8b