### PR TITLE
Ensure latest version is always served

### DIFF
--- a/mcqproject/index.html
+++ b/mcqproject/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MCQ Practice v2025.09 (React)</title>
   </head>

--- a/mcqproject/public/sw.js
+++ b/mcqproject/public/sw.js
@@ -21,33 +21,14 @@ self.addEventListener('activate', (e) => {
 });
 
 self.addEventListener('fetch', (e) => {
-  const req = e.request;
-  if (req.mode === 'navigate') {
-    e.respondWith(
-      fetch(req)
-        .then((res) => {
-          const copy = res.clone();
-          caches.open(CACHE).then((c) => c.put(req, copy));
-          return res;
-        })
-        .catch(() => caches.match(req))
-    );
-    return;
-  }
   e.respondWith(
-    caches
-      .match(req)
-      .then(
-        (hit) =>
-          hit ||
-          fetch(req)
-            .then((res) => {
-              const copy = res.clone();
-              caches.open(CACHE).then((c) => c.put(req, copy));
-              return res;
-            })
-            .catch(() => hit)
-      )
+    fetch(e.request)
+      .then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(e.request, copy));
+        return res;
+      })
+      .catch(() => caches.match(e.request))
   );
 });
 

--- a/mcqproject/src/main.jsx
+++ b/mcqproject/src/main.jsx
@@ -39,5 +39,8 @@ createRoot(document.getElementById('root')).render(
 )
 // PWA: basic service worker registration (production only)
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
-  window.addEventListener('load', () => navigator.serviceWorker.register('/sw.js'));
+  window.addEventListener('load', () => {
+    const swUrl = `/sw.js?ts=${Date.now()}`;
+    navigator.serviceWorker.register(swUrl);
+  });
 }


### PR DESCRIPTION
## Summary
- Add no-cache headers to index.html to discourage browser caching
- Bust service worker cache by versioning registration URL
- Switch service worker to network-first fetching so new assets load immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c55ca88e24832ca24c7e4123fb2cc0