### PR TITLE
Improve repeat page mobile responsiveness

### DIFF
--- a/mcqproject/src/RepeatBuilder.jsx
+++ b/mcqproject/src/RepeatBuilder.jsx
@@ -103,8 +103,8 @@ export default function RepeatBuilder() {
             </div>
           </div>
         </div>
-        <div style={{display:'flex',gap:8,marginTop:12}}>
-          <button type="submit">Start Repeat</button>
+        <div style={{display:'flex',flexWrap:'wrap',gap:8,marginTop:12}}>
+          <button type="submit" style={{flex:1,minWidth:140}}>Start Repeat</button>
         </div>
       </form>
     </div>

--- a/mcqproject/src/index.css
+++ b/mcqproject/src/index.css
@@ -139,8 +139,15 @@ textarea { min-height: 90px; resize: vertical; }
 .toggle input[type="checkbox"]:checked::after { transform: translateX(18px); }
 
 /* Grids */
-.grid-2 { display:grid; grid-template-columns: 1fr 1fr; gap:12px; }
-.grid-3 { display:grid; grid-template-columns: repeat(3, 1fr); gap:12px; }
+.grid-2 { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:12px; }
+.grid-3 { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:12px; }
+@media (max-width: 900px){
+  .grid-3 { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 600px){
+  .grid-2 { grid-template-columns: 1fr; }
+  .grid-3 { grid-template-columns: 1fr; }
+}
 
 /* Tabs */
 .tabs { display:flex; gap:6px; border-bottom:1px solid var(--border-color); margin-bottom:10px; }


### PR DESCRIPTION
## Summary
- Make grid layouts responsive so repeat builder and settings stack on small screens
- Allow columns to shrink to prevent horizontal scroll
- Wrap repeat builder actions for full-width buttons on mobile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55da10480832cb151ae29e38c5058