### PR TITLE
Fix bookmark view toggle on Review screen

### DIFF
--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -18,6 +18,13 @@ export default function Review() {
   const [onlyBookmarked, setOnlyBookmarked] = useState(initialBookmarked);
 
   useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    setOnlyBookmarked(
+      params.get('bookmarks') === '1' || params.get('bookmarks') === 'true'
+    );
+  }, [location.search]);
+
+  useEffect(() => {
     const h = () => setSession(loadSession());
     window.addEventListener('storage', h);
     return () => window.removeEventListener('storage', h);


### PR DESCRIPTION
## Summary
- update Review component to react to `bookmarks` query parameter changes so the Bookmarks nav link works after visiting Review

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c55efc4dec832c8516884833158c89