### PR TITLE
Add new question sets to app dataset

### DIFF
--- a/mcqproject/src/questions.js
+++ b/mcqproject/src/questions.js
@@ -3,10 +3,24 @@ import set2 from './assets/_MConverter.eu_31-60.json' with { type: 'json' };
 import set3 from './assets/_MConverter.eu_61-90.json' with { type: 'json' };
 import set4 from './assets/_MConverter.eu_91-120.json' with { type: 'json' };
 import set5 from './assets/_MConverter.eu_youtube50.json' with { type: 'json' };
+import set6 from './assets/_MConverter.eu_121-150.json' with { type: 'json' };
+import set7 from './assets/_MConverter.eu_151-180.json' with { type: 'json' };
+import set8 from './assets/_MConverter.eu_181-210.json' with { type: 'json' };
+import set9 from './assets/_MConverter.eu_211-254.json' with { type: 'json' };
 
 // Combine all bundled sets into a single array for backward compatibility.
-const defaultQuestions = [...set1, ...set2, ...set3, ...set4, ...set5];
+const defaultQuestions = [
+  ...set1,
+  ...set2,
+  ...set3,
+  ...set4,
+  ...set5,
+  ...set6,
+  ...set7,
+  ...set8,
+  ...set9
+];
 
 export default defaultQuestions;
-export { set1, set2, set3, set4, set5 };
+export { set1, set2, set3, set4, set5, set6, set7, set8, set9 };
 

--- a/mcqproject/test/questions.test.js
+++ b/mcqproject/test/questions.test.js
@@ -1,8 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { set1, set2, set3, set4, set5 } from '../src/questions.js';
+import {
+  set1,
+  set2,
+  set3,
+  set4,
+  set5,
+  set6,
+  set7,
+  set8,
+  set9
+} from '../src/questions.js';
 
-const allSets = { set1, set2, set3, set4, set5 };
+const allSets = { set1, set2, set3, set4, set5, set6, set7, set8, set9 };
 
 test('default sets have expected lengths', () => {
   assert.strictEqual(set1.length, 30);
@@ -10,6 +20,10 @@ test('default sets have expected lengths', () => {
   assert.strictEqual(set3.length, 29);
   assert.strictEqual(set4.length, 26);
   assert.strictEqual(set5.length, 50);
+  assert.strictEqual(set6.length, 23);
+  assert.strictEqual(set7.length, 29);
+  assert.strictEqual(set8.length, 23);
+  assert.strictEqual(set9.length, 35);
 });
 
 test('each question includes an explanation', () => {


### PR DESCRIPTION
## Summary
- include four additional question sets (121-254) in the default dataset
- export all nine sets for modular use
- update tests to validate new set lengths and explanations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6e57060832caa0bdaddc27802c5