### PR TITLE
Seed question sets 6-9 on first app load

### DIFF
--- a/mcqproject/src/main.jsx
+++ b/mcqproject/src/main.jsx
@@ -2,12 +2,32 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { set1, set2, set3, set4, set5 } from './questions.js';
+import {
+  set1,
+  set2,
+  set3,
+  set4,
+  set5,
+  set6,
+  set7,
+  set8,
+  set9,
+} from './questions.js';
 
 // On first load, populate localStorage with the bundled question sets so
 // users have a ready-to-use library without needing to import anything.
-const defaultSets = { set1, set2, set3, set4, set5 };
-const allQuestions = [...set1, ...set2, ...set3, ...set4, ...set5];
+const defaultSets = { set1, set2, set3, set4, set5, set6, set7, set8, set9 };
+const allQuestions = [
+  ...set1,
+  ...set2,
+  ...set3,
+  ...set4,
+  ...set5,
+  ...set6,
+  ...set7,
+  ...set8,
+  ...set9,
+];
 const LS_Q_KEY = 'questions';
 const LS_S_KEY = 'sets';
 


### PR DESCRIPTION
## Summary
- Seed localStorage with new question sets 121-254 so they appear by default

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6c8af7980832c91630b6b872e4f93