### PR TITLE
Ensure bundled question sets sync to local storage

### DIFF
--- a/mcqproject/src/main.jsx
+++ b/mcqproject/src/main.jsx
@@ -13,6 +13,7 @@ import {
   set8,
   set9,
 } from './questions.js';
+import { syncLocalStorage } from './utils/storage.js';
 
 // On first load, populate localStorage with the bundled question sets so
 // users have a ready-to-use library without needing to import anything.
@@ -31,26 +32,7 @@ const allQuestions = [
 const LS_Q_KEY = 'questions';
 const LS_S_KEY = 'sets';
 
-if (!localStorage.getItem(LS_Q_KEY)) {
-  try {
-    localStorage.setItem(LS_Q_KEY, JSON.stringify(allQuestions));
-  } catch {
-    // Ignore write errors (e.g., storage disabled)
-  }
-}
-
-if (!localStorage.getItem(LS_S_KEY)) {
-  try {
-    const sets = Object.entries(defaultSets).map(([name, arr]) => ({
-      id: name,
-      name,
-      questionIds: arr.map((q) => q.id),
-    }));
-    localStorage.setItem(LS_S_KEY, JSON.stringify(sets));
-  } catch {
-    // Ignore write errors
-  }
-}
+syncLocalStorage(defaultSets, allQuestions, localStorage, LS_Q_KEY, LS_S_KEY);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/mcqproject/src/utils/storage.js
+++ b/mcqproject/src/utils/storage.js
@@ -1,0 +1,50 @@
+export function syncLocalStorage(defaultSets, allQuestions, storage, questionsKey = 'questions', setsKey = 'sets') {
+  let existingQuestions = [];
+  try {
+    existingQuestions = JSON.parse(storage.getItem(questionsKey) || '[]');
+  } catch {
+    existingQuestions = [];
+  }
+  const qSet = new Set(existingQuestions.map((q) => JSON.stringify(q)));
+  for (const q of allQuestions) {
+    const str = JSON.stringify(q);
+    if (!qSet.has(str)) {
+      qSet.add(str);
+      existingQuestions.push(q);
+    }
+  }
+  try {
+    storage.setItem(questionsKey, JSON.stringify(existingQuestions));
+  } catch {
+    /* ignore write errors */
+  }
+
+  let existingSets = [];
+  try {
+    existingSets = JSON.parse(storage.getItem(setsKey) || '[]');
+  } catch {
+    existingSets = [];
+  }
+  const sMap = new Map(existingSets.map((s) => [s.id, s]));
+  for (const [name, arr] of Object.entries(defaultSets)) {
+    if (!sMap.has(name)) {
+      sMap.set(name, {
+        id: name,
+        name,
+        questionIds: arr.map((q) => q.id),
+      });
+    } else {
+      const existing = sMap.get(name);
+      const ids = new Set(existing.questionIds);
+      for (const q of arr) {
+        ids.add(q.id);
+      }
+      existing.questionIds = Array.from(ids);
+    }
+  }
+  try {
+    storage.setItem(setsKey, JSON.stringify([...sMap.values()]));
+  } catch {
+    /* ignore write errors */
+  }
+}

--- a/mcqproject/test/storage.test.js
+++ b/mcqproject/test/storage.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+  set1,
+  set2,
+  set3,
+  set4,
+  set5,
+  set6,
+  set7,
+  set8,
+  set9,
+} from '../src/questions.js';
+import { syncLocalStorage } from '../src/utils/storage.js';
+
+function createMockStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) delete store[key];
+    },
+  };
+}
+
+const defaultSets = { set1, set2, set3, set4, set5, set6, set7, set8, set9 };
+const allQuestions = [
+  ...set1,
+  ...set2,
+  ...set3,
+  ...set4,
+  ...set5,
+  ...set6,
+  ...set7,
+  ...set8,
+  ...set9,
+];
+
+test('initializes empty storage with all default data', () => {
+  const storage = createMockStorage();
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+  const savedSets = JSON.parse(storage.getItem('s'));
+  const savedQuestions = JSON.parse(storage.getItem('q'));
+  assert.strictEqual(savedSets.length, 9);
+  assert.strictEqual(savedQuestions.length, allQuestions.length);
+});
+
+test('adds new sets and questions without duplication', () => {
+  const storage = createMockStorage();
+  const initialQuestions = [...set1, ...set2, ...set3, ...set4, ...set5];
+  const initialSets = Object.entries({ set1, set2, set3, set4, set5 }).map(
+    ([id, arr]) => ({
+      id,
+      name: id,
+      questionIds: arr.map((q) => q.id),
+    }),
+  );
+  storage.setItem('q', JSON.stringify(initialQuestions));
+  storage.setItem('s', JSON.stringify(initialSets));
+
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+
+  const savedSets = JSON.parse(storage.getItem('s'));
+  const ids = savedSets.map((s) => s.id);
+  assert.deepStrictEqual(ids, [
+    'set1',
+    'set2',
+    'set3',
+    'set4',
+    'set5',
+    'set6',
+    'set7',
+    'set8',
+    'set9',
+  ]);
+  const savedQuestions = JSON.parse(storage.getItem('q'));
+  assert.strictEqual(savedQuestions.length, allQuestions.length);
+});


### PR DESCRIPTION
## Summary
- load default question sets into storage on every startup
- add utility to merge new sets and questions without duplicates
- cover local storage sync with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cd11bed0832c85a409614b9e0346