### PR TITLE
Add quick repeat count options and fix session resume

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -989,8 +989,9 @@ function Quiz() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const mode = params.get('mode') || 'practice';
+  const resume = params.get('resume') === '1' || params.get('resume') === 'true';
   const setParam = params.get('setId');
-  if (!setParam) {
+  if (!setParam && !resume) {
     return <QuizSetup mode={mode} />;
   }
   return <QuizMain />;

--- a/mcqproject/src/RepeatBuilder.jsx
+++ b/mcqproject/src/RepeatBuilder.jsx
@@ -69,7 +69,34 @@ export default function RepeatBuilder() {
               </div>
             </div>
             <div style={{marginTop:8}}>
-              <label>Count <input type="number" min="1" value={count} onChange={(e)=>setCount(e.target.value)} /></label>
+              <label style={{display:'block', marginBottom:4}}>Count</label>
+              <div className="chips" style={{alignItems:'center',flexWrap:'wrap'}}>
+                {[10,20].map(n => (
+                  <button
+                    type="button"
+                    key={n}
+                    className={`chip ${count===String(n)?'accent':''}`}
+                    onClick={()=>setCount(String(n))}
+                  >
+                    {n}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  className={`chip ${count===''?'accent':''}`}
+                  onClick={()=>setCount('')}
+                >
+                  All
+                </button>
+                <input
+                  type="number"
+                  min="1"
+                  placeholder="Custom"
+                  value={count}
+                  onChange={(e)=>setCount(e.target.value)}
+                  style={{width:80,marginLeft:4}}
+                />
+              </div>
             </div>
           </div>
           <div className="card" style={{padding:'12px'}}>


### PR DESCRIPTION
## Summary
- add 10/20/All quick buttons for Repeat Adaptive question count
- allow resuming last session without selecting a set again

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e0c76b44832cb8338f316e42bbe5