### PR TITLE
Fix bookmark isolation and retry incorrect handling

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -664,7 +664,7 @@ function QuizMain() {
   };
 
   const retryIncorrect = () => {
-    const subset = questions.filter((q, i) => {
+    const ids = questions.reduce((acc, q, i) => {
       const corr = Array.isArray(q.correct)
         ? q.correct
         : Array.isArray(q.answers)
@@ -675,15 +675,18 @@ function QuizMain() {
         ? [q.answer]
         : [];
       const sel = Array.isArray(answers[i]) ? answers[i] : [];
-      const ok =
-        sel.length === corr.length && corr.every((n) => sel.includes(n));
-      return !ok;
-    });
-    if (subset.length === 0) {
+      const ok = sel.length === corr.length && corr.every((n) => sel.includes(n));
+      if (!ok) acc.push(q.id);
+      return acc;
+    }, []);
+    if (ids.length === 0) {
       alert('No incorrect answers to retry.');
       return;
     }
-    restart(subset);
+    try { localStorage.setItem('retryIds', JSON.stringify(ids)); } catch {
+      /* ignore */
+    }
+    window.location.href = `/quiz?mode=${encodeURIComponent(mode)}`;
   };
 
   // Auto-finish convenience: if feedback is onSelect and on last question, grade shortly after reveal

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { toast } from './utils/toast.js';
 import { ensureKatex, renderMDKaTeX } from './utils/katex';
+import defaultQuestions from './questions';
 
 function loadSession() {
   try { return JSON.parse(localStorage.getItem('mcqSession') || '{}'); } catch { return {}; }
@@ -16,6 +17,13 @@ export default function Review() {
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('');
   const [onlyBookmarked, setOnlyBookmarked] = useState(initialBookmarked);
+  const [bookmarks, setBookmarks] = useState(() => {
+    try {
+      return new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]'));
+    } catch {
+      return new Set();
+    }
+  });
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -25,14 +33,35 @@ export default function Review() {
   }, [location.search]);
 
   useEffect(() => {
-    const h = () => setSession(loadSession());
+    const h = () => {
+      setSession(loadSession());
+      try {
+        setBookmarks(new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]')));
+      } catch {
+        /* ignore */
+      }
+    };
     window.addEventListener('storage', h);
     return () => window.removeEventListener('storage', h);
   }, []);
   useEffect(() => { ensureKatex(); }, []);
 
-  const allQuestions = session.questions || [];
-  const bookmarks = new Set(session.bookmarks || []);
+  const allQuestions = useMemo(() => {
+    if (onlyBookmarked) {
+      let dataset = defaultQuestions;
+      try {
+        const raw = localStorage.getItem('questions');
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed) && parsed.length) dataset = parsed;
+        }
+      } catch {
+        /* keep defaults */
+      }
+      return dataset.map((q, idx) => ({ ...q, id: q.id ?? idx + 1 }));
+    }
+    return session.questions || [];
+  }, [onlyBookmarked, session]);
   const results = session.results || [];
 
   const tags = useMemo(() => {
@@ -55,15 +84,21 @@ export default function Review() {
   }, [allQuestions, bookmarks, onlyBookmarked, tag, query]);
 
   const toggleBookmark = (id) => {
+    setBookmarks((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      try { localStorage.setItem('bookmarks', JSON.stringify([...next])); } catch {
+        /* ignore */
+      }
+      return next;
+    });
     setSession((prev) => {
       const set = new Set(prev.bookmarks || []);
       if (set.has(id)) set.delete(id);
       else set.add(id);
       const updated = { ...prev, bookmarks: [...set] };
-      try {
-        localStorage.setItem('bookmarks', JSON.stringify(updated.bookmarks));
-        localStorage.setItem('mcqSession', JSON.stringify(updated));
-      } catch {
+      try { localStorage.setItem('mcqSession', JSON.stringify(updated)); } catch {
         /* ignore */
       }
       return updated;


### PR DESCRIPTION
## Summary
- Load bookmarks independently of review session and keep them in local storage
- Reload bookmarked questions directly from stored dataset
- Persist incorrect answers to retry across sessions and restart quiz with all of them

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'with')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc103694832c9d88bfec90ba4d7f