### PR TITLE
Normalize bookmark IDs to prevent duplicate entries

### DIFF
--- a/mcqproject/src/LandingPage.jsx
+++ b/mcqproject/src/LandingPage.jsx
@@ -7,7 +7,10 @@ function LandingPage() {
   const countOptions = [10, 20, 25, 30];
   let qCount = 0, bmCount = 0;
   try { qCount = JSON.parse(localStorage.getItem('questions')||'[]').length; } catch { /* ignore */ }
-  try { bmCount = JSON.parse(localStorage.getItem('bookmarks')||'[]').length; } catch { /* ignore */ }
+  try {
+    const b = JSON.parse(localStorage.getItem('bookmarks')||'[]');
+    bmCount = Array.isArray(b) ? new Set(b.map(Number)).size : 0;
+  } catch { /* ignore */ }
   let session=null; try { session = JSON.parse(localStorage.getItem('mcqSession')||'null'); } catch { /* ignore */ }
   let sets=[]; try { sets = JSON.parse(localStorage.getItem('sets')||'[]'); } catch { /* ignore */ }
   return (

--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -41,7 +41,8 @@ function QuizSetup({ mode }) {
     /* ignore */
   }
   try {
-    bmCount = JSON.parse(localStorage.getItem('bookmarks') || '[]').length;
+    const b = JSON.parse(localStorage.getItem('bookmarks') || '[]');
+    bmCount = Array.isArray(b) ? new Set(b.map(Number)).size : 0;
   } catch {
     /* ignore */
   }
@@ -136,7 +137,15 @@ function QuizMain() {
   const resume = params.get('resume') === '1' || params.get('resume') === 'true';
   const sessionData = useMemo(() => {
     if (!resume) return null;
-    try { return JSON.parse(localStorage.getItem('mcqSession') || 'null'); } catch { return null; }
+    try {
+      const data = JSON.parse(localStorage.getItem('mcqSession') || 'null');
+      if (data && Array.isArray(data.bookmarks)) {
+        data.bookmarks = data.bookmarks.map(Number);
+      }
+      return data;
+    } catch {
+      return null;
+    }
   }, [resume]);
   const buildQuestions = () => {
     // Load dataset safely without throwing
@@ -176,7 +185,7 @@ function QuizMain() {
       if (setId === 'bookmarks') {
         try {
           const bm = JSON.parse(localStorage.getItem('bookmarks') || '[]');
-          const idSet = new Set(bm);
+          const idSet = new Set(Array.isArray(bm) ? bm.map(Number) : []);
           arr = arr.filter((q) => idSet.has(q.id));
         } catch { /* ignore */ }
       } else if (setId && setId !== 'all') {
@@ -274,11 +283,13 @@ function QuizMain() {
   const [resIncorrectOnly, setResIncorrectOnly] = useState(false);
   const [resSearch, setResSearch] = useState('');
   const [bookmarks, setBookmarks] = useState(() => {
-    if (sessionData) return new Set(sessionData.bookmarks || []);
+    if (sessionData) return new Set((sessionData.bookmarks || []).map(Number));
     try {
       const b = JSON.parse(localStorage.getItem('bookmarks') || '[]');
-      return new Set(Array.isArray(b) ? b : []);
-    } catch { return new Set(); }
+      return new Set(Array.isArray(b) ? b.map(Number) : []);
+    } catch {
+      return new Set();
+    }
   });
   const [notes, setNotes] = useState(() => {
     if (sessionData) return sessionData.notes || {};
@@ -589,13 +600,13 @@ function QuizMain() {
   };
 
   const toggleBookmark = () => {
-    const id = question.id;
+    const id = Number(question.id);
     const next = new Set(bookmarks);
     if (next.has(id)) next.delete(id); else next.add(id);
     setBookmarks(next);
     localStorage.setItem('bookmarks', JSON.stringify([...next]));
     localStorage.setItem('mcqSession', JSON.stringify({
-      ...(JSON.parse(localStorage.getItem('mcqSession')||'{}')),
+      ...(JSON.parse(localStorage.getItem('mcqSession') || '{}')),
       bookmarks: [...next],
     }));
     toast(next.has(id) ? 'Bookmarked' : 'Removed bookmark');

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -5,7 +5,15 @@ import { ensureKatex, renderMDKaTeX } from './utils/katex';
 import defaultQuestions from './questions';
 
 function loadSession() {
-  try { return JSON.parse(localStorage.getItem('mcqSession') || '{}'); } catch { return {}; }
+  try {
+    const data = JSON.parse(localStorage.getItem('mcqSession') || '{}');
+    if (data && Array.isArray(data.bookmarks)) {
+      data.bookmarks = data.bookmarks.map(Number);
+    }
+    return data;
+  } catch {
+    return {};
+  }
 }
 
 export default function Review() {
@@ -19,7 +27,8 @@ export default function Review() {
   const [onlyBookmarked, setOnlyBookmarked] = useState(initialBookmarked);
   const [bookmarks, setBookmarks] = useState(() => {
     try {
-      return new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]'));
+      const b = JSON.parse(localStorage.getItem('bookmarks') || '[]');
+      return new Set(Array.isArray(b) ? b.map(Number) : []);
     } catch {
       return new Set();
     }
@@ -36,7 +45,8 @@ export default function Review() {
     const h = () => {
       setSession(loadSession());
       try {
-        setBookmarks(new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]')));
+        const b = JSON.parse(localStorage.getItem('bookmarks') || '[]');
+        setBookmarks(new Set(Array.isArray(b) ? b.map(Number) : []));
       } catch {
         /* ignore */
       }
@@ -84,19 +94,20 @@ export default function Review() {
   }, [allQuestions, bookmarks, onlyBookmarked, tag, query]);
 
   const toggleBookmark = (id) => {
+    const idNum = Number(id);
     setBookmarks((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(idNum)) next.delete(idNum);
+      else next.add(idNum);
       try { localStorage.setItem('bookmarks', JSON.stringify([...next])); } catch {
         /* ignore */
       }
       return next;
     });
     setSession((prev) => {
-      const set = new Set(prev.bookmarks || []);
-      if (set.has(id)) set.delete(id);
-      else set.add(id);
+      const set = new Set((prev.bookmarks || []).map(Number));
+      if (set.has(idNum)) set.delete(idNum);
+      else set.add(idNum);
       const updated = { ...prev, bookmarks: [...set] };
       try { localStorage.setItem('mcqSession', JSON.stringify(updated)); } catch {
         /* ignore */


### PR DESCRIPTION
## Summary
- Normalize bookmark IDs from storage to numbers across the app
- Ensure bookmark toggles operate on numeric IDs, allowing proper removal
- Deduplicate bookmark counts on landing page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c702143628832c93cf0a97a187a50a