### PR TITLE
Fix retry incorrect navigation

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -132,6 +132,7 @@ function QuizSetup({ mode }) {
 
 function QuizMain() {
   const location = useLocation();
+  const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const mode = params.get('mode') || 'practice'; // practice | test | challenge
   const resume = params.get('resume') === '1' || params.get('resume') === 'true';
@@ -697,7 +698,7 @@ function QuizMain() {
     try { localStorage.setItem('retryIds', JSON.stringify(ids)); } catch {
       /* ignore */
     }
-    window.location.href = `/quiz?mode=${encodeURIComponent(mode)}`;
+    navigate(`/quiz?mode=${encodeURIComponent(mode)}`);
   };
 
   // Auto-finish convenience: if feedback is onSelect and on last question, grade shortly after reveal

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from './utils/toast.js';
 import { ensureKatex, renderMDKaTeX } from './utils/katex';
 import defaultQuestions from './questions';
@@ -18,6 +18,7 @@ function loadSession() {
 
 export default function Review() {
   const location = useLocation();
+  const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const initialBookmarked = params.get('bookmarks') === '1' || params.get('bookmarks') === 'true';
 
@@ -126,7 +127,7 @@ export default function Review() {
       return;
     }
     try { localStorage.setItem('retryIds', JSON.stringify(ids)); } catch { /* ignore */ }
-    window.location.href = `/quiz?mode=${encodeURIComponent(session.mode || 'practice')}`;
+    navigate(`/quiz?mode=${encodeURIComponent(session.mode || 'practice')}`);
   };
 
   const exportCSV = () => {


### PR DESCRIPTION
## Summary
- Use React Router navigation when retrying incorrect questions to avoid 404 reloads
- Apply same navigation fix in Review page for retrying incorrect items

## Testing
- `npm test`
- `npm run lint` *(fails: 0, warnings: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68c70dbded58832ca39494f880d7affc