### PR TITLE
Retry incorrect quiz questions without leaving session

### DIFF
--- a/mcqproject/src/Quiz.jsx
+++ b/mcqproject/src/Quiz.jsx
@@ -132,7 +132,6 @@ function QuizSetup({ mode }) {
 
 function QuizMain() {
   const location = useLocation();
-  const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const mode = params.get('mode') || 'practice'; // practice | test | challenge
   const resume = params.get('resume') === '1' || params.get('resume') === 'true';
@@ -676,7 +675,7 @@ function QuizMain() {
   };
 
   const retryIncorrect = () => {
-    const ids = questions.reduce((acc, q, i) => {
+    const incorrect = questions.filter((q, i) => {
       const corr = Array.isArray(q.correct)
         ? q.correct
         : Array.isArray(q.answers)
@@ -688,17 +687,13 @@ function QuizMain() {
         : [];
       const sel = Array.isArray(answers[i]) ? answers[i] : [];
       const ok = sel.length === corr.length && corr.every((n) => sel.includes(n));
-      if (!ok) acc.push(q.id);
-      return acc;
-    }, []);
-    if (ids.length === 0) {
+      return !ok;
+    });
+    if (incorrect.length === 0) {
       alert('No incorrect answers to retry.');
       return;
     }
-    try { localStorage.setItem('retryIds', JSON.stringify(ids)); } catch {
-      /* ignore */
-    }
-    navigate(`/quiz?mode=${encodeURIComponent(mode)}`);
+    restart(incorrect);
   };
 
   // Auto-finish convenience: if feedback is onSelect and on last question, grade shortly after reveal

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -118,16 +118,27 @@ export default function Review() {
   };
 
   const retryIncorrect = () => {
-    const ids = (results || [])
+    const incorrect = (results || [])
       .filter((r) => !r.isCorrect)
-      .map((r) => allQuestions[r.index]?.id)
+      .map((r) => session.questions?.[r.index])
       .filter(Boolean);
-    if (ids.length === 0) {
+    if (incorrect.length === 0) {
       toast('No incorrect questions to retry.');
       return;
     }
-    try { localStorage.setItem('retryIds', JSON.stringify(ids)); } catch { /* ignore */ }
-    navigate(`/quiz?mode=${encodeURIComponent(session.mode || 'practice')}`);
+    const payload = {
+      mode: session.mode || 'practice',
+      current: 0,
+      questions: incorrect,
+      results: [],
+      bookmarks: session.bookmarks || [],
+      notes: session.notes || {},
+      score: 0,
+      points: 0,
+      times: [],
+    };
+    try { localStorage.setItem('mcqSession', JSON.stringify(payload)); } catch { /* ignore */ }
+    navigate(`/quiz?mode=${encodeURIComponent(session.mode || 'practice')}&resume=1`);
   };
 
   const exportCSV = () => {


### PR DESCRIPTION
## Summary
- Restart quizzes with only incorrect answers instead of navigating away
- Allow review screen to relaunch a quiz limited to missed questions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c70f615f44832c81f908e7ea934782