### PR TITLE
Fix set filtering on questions page

### DIFF
--- a/mcqproject/src/Import.jsx
+++ b/mcqproject/src/Import.jsx
@@ -36,11 +36,16 @@ function ImportQuestions() {
   const [pasteText, setPasteText] = useState('');
   const [pasteError, setPasteError] = useState('');
   const questionAssignments = useMemo(() => {
+    // Build a map of questionId -> [setId, ...]. Use strings for
+    // keys/values to avoid number/string mismatches which previously
+    // broke filtering when set IDs were non-numeric.
     const map = new Map();
     sets.forEach((s) => {
+      const sid = String(s.id);
       (s.questionIds || []).forEach((id) => {
-        if (!map.has(id)) map.set(id, []);
-        map.get(id).push(s.id);
+        const qid = String(id);
+        if (!map.has(qid)) map.set(qid, []);
+        map.get(qid).push(sid);
       });
     });
     return map;
@@ -319,11 +324,11 @@ function ImportQuestions() {
   const filteredQuestions = useMemo(() => {
     const term = search.trim().toLowerCase();
     return questions.filter((q) => {
-      const assignedTo = questionAssignments.get(q.id) || [];
+      const assignedTo = questionAssignments.get(String(q.id)) || [];
       const isAssigned = assignedTo.length > 0;
       if (assignFilter === 'assigned' && !isAssigned) return false;
       if (assignFilter === 'unassigned' && isAssigned) return false;
-      if (filterSet && !assignedTo.includes(Number(filterSet))) return false;
+      if (filterSet && !assignedTo.includes(String(filterSet))) return false;
       if (!term) return true;
       return (
         q.question.toLowerCase().includes(term) ||

--- a/mcqproject/test/filterSets.test.js
+++ b/mcqproject/test/filterSets.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+function filterQuestions(questions, sets, filterSet) {
+  const map = new Map();
+  sets.forEach((s) => {
+    const sid = String(s.id);
+    (s.questionIds || []).forEach((id) => {
+      const qid = String(id);
+      if (!map.has(qid)) map.set(qid, []);
+      map.get(qid).push(sid);
+    });
+  });
+  return questions.filter((q) => {
+    const assignedTo = map.get(String(q.id)) || [];
+    if (filterSet && !assignedTo.includes(String(filterSet))) return false;
+    return true;
+  });
+}
+
+test('filters questions by set id regardless of id type', () => {
+  const questions = [{ id: 1, question: 'Q1', options: [], answers: [] }];
+  const sets = [{ id: 'abc', questionIds: [1] }];
+  const res = filterQuestions(questions, sets, 'abc');
+  assert.strictEqual(res.length, 1);
+  const none = filterQuestions(questions, sets, 'xyz');
+  assert.strictEqual(none.length, 0);
+});


### PR DESCRIPTION
## Summary
- Normalize question and set IDs as strings when building assignment map
- Apply string-based filtering for sets on the questions page
- Add regression test ensuring filtering works with non-numeric set IDs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80e17b4b4832cb9c5010c3e3fe839