### PR TITLE
Handle question IDs internally during import/export

### DIFF
--- a/mcqproject/src/Import.jsx
+++ b/mcqproject/src/Import.jsx
@@ -139,7 +139,9 @@ function ImportQuestions() {
 
   const prepareImport = (arr) =>
     ensureUniqueIds(
-      arr.map((q) => normalizeQuestion({ ...q, id: q.id ?? generateId() }))
+      // Always generate a new ID so imported data doesn't reuse any
+      // pre-existing identifiers that might conflict with local sets.
+      arr.map((q) => normalizeQuestion({ ...q, id: generateId() }))
     );
 
   const persistQuestions = (updater) => {

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -185,12 +185,17 @@ export default function Review() {
   };
 
   const exportQuestion = (q) => {
-    const blob = new Blob([JSON.stringify(q, null, 2)], { type: 'application/json' });
+    // Exclude the question ID from the exported JSON to avoid clashes
+    // when re-importing into other instances.
+    const { id, ...rest } = q;
+    const blob = new Blob([JSON.stringify(rest, null, 2)], {
+      type: 'application/json',
+    });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = `q${q.id}.json`;
+    a.download = `q${id}.json`;
     a.click();
-    toast(`Exported q${q.id}.json`);
+    toast(`Exported q${id}.json`);
   };
 
   const exportCSV = () => {


### PR DESCRIPTION
## Summary
- Always generate new IDs when importing questions to avoid cross-set collisions
- Strip IDs from exported question JSON to prevent re-import conflicts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c813413720832caf716037977fe524