### PR TITLE
Revamp bookmarks page with modern card layout

### DIFF
--- a/mcqproject/src/App.css
+++ b/mcqproject/src/App.css
@@ -199,6 +199,98 @@ body.dark .nav {
   width: 100%;
 }
 
+/* Bookmarks page layout */
+.bookmarks-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+}
+@media (max-width: 900px) {
+  .bookmarks-layout {
+    grid-template-columns: 1fr;
+  }
+}
+.bm-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.bm-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.question-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+.question-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.qc-top {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.qc-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 4px;
+}
+.qc-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 6px;
+}
+.progress-card .progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 4px;
+}
+.progress-card .progress {
+  flex: 1;
+  height: 6px;
+  border-radius: 4px;
+  background: var(--bar-bg);
+  overflow: hidden;
+}
+.progress-card .progress-bar {
+  height: 100%;
+  background: var(--accent-color);
+}
+.chip.status.correct {
+  border-color: var(--success);
+  color: var(--success);
+  background: rgba(34, 197, 94, 0.1);
+}
+.chip.status.incorrect {
+  border-color: var(--danger);
+  color: var(--danger);
+  background: rgba(239, 68, 68, 0.1);
+}
+.chip.status.unanswered {
+  border-color: var(--border-color);
+  background: rgba(148, 163, 184, 0.1);
+}
+.chip.difficulty.easy {
+  border-color: #22c55e;
+  color: #22c55e;
+}
+.chip.difficulty.medium {
+  border-color: #eab308;
+  color: #eab308;
+}
+.chip.difficulty.hard {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
 .nav a.active {
   font-weight: 600;
 }

--- a/mcqproject/src/Review.jsx
+++ b/mcqproject/src/Review.jsx
@@ -27,6 +27,7 @@ export default function Review() {
   const [tag, setTag] = useState('');
   const [setFilter, setSetFilter] = useState('');
   const [difficulty, setDifficulty] = useState('');
+  const [sortBy, setSortBy] = useState('date');
   const [compact, setCompact] = useState(false);
   const [expanded, setExpanded] = useState(new Set());
   const [onlyBookmarked, setOnlyBookmarked] = useState(initialBookmarked);
@@ -99,7 +100,7 @@ export default function Review() {
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return allQuestions.filter((it) => {
+    const arr = allQuestions.filter((it) => {
       if (onlyBookmarked && !bookmarks.has(it.id)) return false;
       if (tag && !(it.tags || []).includes(tag)) return false;
       if (setFilter && it.set !== setFilter) return false;
@@ -110,7 +111,14 @@ export default function Review() {
         (it.options || []).some((o) => String(o).toLowerCase().includes(q))
       );
     });
-  }, [allQuestions, bookmarks, onlyBookmarked, tag, setFilter, difficulty, query]);
+    arr.sort((a, b) => {
+      if (sortBy === 'set') return (a.set || '').localeCompare(b.set || '');
+      if (sortBy === 'difficulty')
+        return (a.difficulty || '').localeCompare(b.difficulty || '');
+      return 0;
+    });
+    return arr;
+  }, [allQuestions, bookmarks, onlyBookmarked, tag, setFilter, difficulty, query, sortBy]);
 
   const toggleBookmark = (id) => {
     const idNum = Number(id);
@@ -227,77 +235,241 @@ export default function Review() {
     return map;
   }, [allQuestions, bookmarks, results]);
 
+  const totalSets = Object.keys(progressBySet).length;
+  const totalWrong = Object.values(progressBySet).reduce((a, b) => a + b.wrong, 0);
+
   return (
-    <div className="card">
-      <h2>{onlyBookmarked ? 'Bookmarks' : 'Review'}</h2>
-      <div className="toolbar" style={{marginBottom:'8px',display:'flex',flexWrap:'wrap',gap:'6px'}}>
-        <input placeholder="Search" value={query} onChange={(e)=>setQuery(e.target.value)} />
-        <select value={tag} onChange={(e)=>setTag(e.target.value)}>
-          {tags.map((t) => (
-            <option key={t} value={t}>{t||'All tags'}</option>
-          ))}
-        </select>
-        <select value={setFilter} onChange={(e)=>setSetFilter(e.target.value)}>
-          {sets.map((s) => (
-            <option key={s} value={s}>{s||'All sets'}</option>
-          ))}
-        </select>
-        <select value={difficulty} onChange={(e)=>setDifficulty(e.target.value)}>
-          {difficulties.map((d) => (
-            <option key={d} value={d}>{d||'All difficulties'}</option>
-          ))}
-        </select>
-        <label className="toggle"><input type="checkbox" checked={onlyBookmarked} onChange={(e)=>setOnlyBookmarked(e.target.checked)} /> Bookmarked</label>
-        <button className="btn-ghost" onClick={()=>setCompact(c=>!c)}>{compact?'Detailed':'Compact'} View</button>
-        <button className="btn-outline" onClick={retryIncorrect}>Retry Incorrect Only</button>
-        <button className="btn-ghost" onClick={exportCSV}>Export CSV</button>
-        <button className="btn-ghost" onClick={exportJSON}>Export JSON</button>
-      </div>
-      <div className="progress-summary" style={{display:'flex',flexWrap:'wrap',gap:'6px',marginBottom:'8px'}}>
-        {Object.entries(progressBySet).map(([s,data]) => (
-          <span key={s} className="badge">{`${s}: ${data.total} (${data.wrong} wrong)`}</span>
-        ))}
-      </div>
-      <ul style={{listStyle:'none',padding:0,margin:0,display:'flex',flexDirection:'column',gap:'10px'}}>
-        {filtered.map((q) => {
-          const idx = allQuestions.findIndex((x) => x.id === q.id);
-          const res = results[idx];
-          const your = (res?.selected || []).map((n) => q.options[n]).join(', ');
-          const corr = (q.correct || []).map((n) => q.options[n]).join(', ');
-          const snippet = q.question.length > 120 ? q.question.slice(0,120)+'…' : q.question;
-          const isExpanded = expanded.has(q.id);
-          const liClass = compact ? 'bookmark-item compact' : 'bookmark-item card';
-          return (
-            <li key={q.id} className={liClass} style={compact?{padding:'6px 0'}:{padding:'12px'}}>
-              <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',cursor:'pointer'}} onClick={()=>toggleExpand(q.id)}>
-                <div style={{display:'flex',alignItems:'center',gap:'4px'}}>
-                  <strong>Q{idx+1}.</strong>
-                  <span dangerouslySetInnerHTML={{__html: renderMDKaTeX(snippet)}}></span>
+    <div className="bookmarks-layout">
+      <aside className="bm-sidebar card">
+        <input
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <div>
+          <h4>Tags</h4>
+          <div className="chips">
+            {tags.map((t) => (
+              <button
+                key={t}
+                className={`chip ${tag === t ? 'accent' : ''}`}
+                onClick={() => setTag(t)}
+              >
+                {t || 'All'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4>Sets</h4>
+          <div className="chips">
+            {sets.map((s) => (
+              <button
+                key={s}
+                className={`chip ${setFilter === s ? 'accent' : ''}`}
+                onClick={() => setSetFilter(s)}
+              >
+                {s || 'All'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4>Difficulty</h4>
+          <div className="chips">
+            {difficulties.map((d) => (
+              <button
+                key={d}
+                className={`chip ${difficulty === d ? 'accent' : ''}`}
+                onClick={() => setDifficulty(d)}
+              >
+                {d || 'All'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={onlyBookmarked}
+            onChange={(e) => setOnlyBookmarked(e.target.checked)}
+          />
+          Bookmarked
+        </label>
+        <button
+          className="btn-ghost"
+          onClick={() => setCompact((c) => !c)}
+        >
+          {compact ? 'Detailed' : 'Compact'} View
+        </button>
+      </aside>
+      <section className="bm-main">
+        <div
+          className="main-toolbar"
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+            gap: '8px',
+            marginBottom: '8px',
+          }}
+        >
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+            <option value="date">By Date</option>
+            <option value="set">By Set</option>
+            <option value="difficulty">By Difficulty</option>
+          </select>
+          <button className="btn primary" onClick={retryIncorrect}>
+            Retry Incorrect Only
+          </button>
+          <button
+            type="button"
+            className="icon-btn"
+            onClick={exportCSV}
+            title="Export CSV"
+          >
+            ⬇️
+          </button>
+          <button
+            type="button"
+            className="icon-btn"
+            onClick={exportJSON}
+            title="Export JSON"
+          >
+            ⬇️
+          </button>
+        </div>
+        <div className="card progress-card">
+          <div>
+            {totalSets} sets bookmarked, {totalWrong} incorrect left to retry
+          </div>
+          {Object.entries(progressBySet).map(([s, data]) => {
+            const pct = ((data.total - data.wrong) / data.total) * 100;
+            return (
+              <div key={s} className="progress-row">
+                <span>{s}</span>
+                <div className="progress">
+                  <div
+                    className="progress-bar"
+                    style={{ width: pct + '%' }}
+                  ></div>
                 </div>
-                <div style={{display:'flex',alignItems:'center',gap:'6px'}}>
-                  {q.set && <span className="badge">{q.set}</span>}
-                  <div style={{display:'flex',gap:'4px'}} onClick={(e)=>e.stopPropagation()}>
-                    {onlyBookmarked ? (
-                      <button type="button" className="icon-btn" onClick={()=>toggleBookmark(q.id)} title="Remove bookmark">✕</button>
-                    ) : (
-                      <button type="button" className="icon-btn" onClick={()=>toggleBookmark(q.id)} title="Toggle bookmark">{bookmarks.has(q.id)?'★':'☆'}</button>
-                    )}
-                    <button type="button" className="icon-btn" onClick={()=>retryOne(q)} title="Retry">↻</button>
-                    <button type="button" className="icon-btn" onClick={()=>exportQuestion(q)} title="Export">⤓</button>
-                  </div>
-                </div>
+                <span>
+                  {data.total - data.wrong}/{data.total}
+                </span>
               </div>
-              {isExpanded && (
-                <div style={{marginTop:'6px'}}>
-                  <div><strong>Your:</strong> <span dangerouslySetInnerHTML={{__html: renderMDKaTeX(your || '—')}}></span></div>
-                  <div><strong>Correct:</strong> <span dangerouslySetInnerHTML={{__html: renderMDKaTeX(corr)}}></span></div>
-                  {q.explanation && <div style={{marginTop:'6px'}} className="muted" dangerouslySetInnerHTML={{__html: renderMDKaTeX(q.explanation)}}></div>}
+            );
+          })}
+        </div>
+        <div className="question-grid">
+          {filtered.map((q) => {
+            const idx = allQuestions.findIndex((x) => x.id === q.id);
+            const res = results[idx];
+            const your = (res?.selected || []).map((n) => q.options[n]).join(', ');
+            const corr = (q.correct || []).map((n) => q.options[n]).join(', ');
+            const snippet =
+              q.question.length > 120
+                ? q.question.slice(0, 120) + '…'
+                : q.question;
+            const isExpanded = expanded.has(q.id);
+            const status = res
+              ? res.isCorrect
+                ? 'correct'
+                : 'incorrect'
+              : 'unanswered';
+            return (
+              <div
+                key={q.id}
+                className={`question-card ${compact ? '' : 'card'}`}
+              >
+                <div
+                  className="qc-header"
+                  onClick={() => toggleExpand(q.id)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <div className="qc-top">
+                    <strong>Q{idx + 1}</strong>
+                    {q.set && <span className="chip">{q.set}</span>}
+                  </div>
+                  <div className="qc-tags">
+                    <span className={`chip status ${status}`}>
+                      {status.charAt(0).toUpperCase() + status.slice(1)}
+                    </span>
+                    {q.difficulty && (
+                      <span
+                        className={`chip difficulty ${q.difficulty?.toLowerCase?.()}`}
+                      >
+                        {q.difficulty}
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    className="qc-question"
+                    dangerouslySetInnerHTML={{
+                      __html: renderMDKaTeX(snippet),
+                    }}
+                  ></div>
                 </div>
-              )}
-            </li>
-          );
-        })}
-      </ul>
+                <div className="qc-actions">
+                  <button
+                    type="button"
+                    className="icon-btn"
+                    onClick={() => retryOne(q)}
+                    title="Retry"
+                  >
+                    🔄
+                  </button>
+                  <button
+                    type="button"
+                    className="icon-btn"
+                    onClick={() => toggleBookmark(q.id)}
+                    title="Unbookmark"
+                  >
+                    {bookmarks.has(q.id) ? '⭐' : '☆'}
+                  </button>
+                  <button
+                    type="button"
+                    className="icon-btn"
+                    onClick={() => exportQuestion(q)}
+                    title="Export"
+                  >
+                    ⬇️
+                  </button>
+                </div>
+                {isExpanded && (
+                  <div className="qc-extra">
+                    <div>
+                      <strong>Your:</strong>{' '}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: renderMDKaTeX(your || '—'),
+                        }}
+                      ></span>
+                    </div>
+                    <div>
+                      <strong>Correct:</strong>{' '}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: renderMDKaTeX(corr),
+                        }}
+                      ></span>
+                    </div>
+                    {q.explanation && (
+                      <div
+                        style={{ marginTop: '6px' }}
+                        className="muted"
+                        dangerouslySetInnerHTML={{
+                          __html: renderMDKaTeX(q.explanation),
+                        }}
+                      ></div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Implement two-column bookmarks layout with sidebar filters and sort options
- Add progress overview and difficulty/status chips for each question card
- Include action toolbar for retrying and exporting bookmarked questions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c81dfd186c832c8c3d984498bb56b2