### PR TITLE
Prevent duplicate default questions on reload

### DIFF
--- a/mcqproject/src/utils/storage.js
+++ b/mcqproject/src/utils/storage.js
@@ -1,3 +1,62 @@
+const OMIT_KEYS = new Set(['id', 'set', 'setIds']);
+
+function normalizeAnswers(q) {
+  const arr = Array.isArray(q.answers)
+    ? q.answers
+    : Array.isArray(q.answer)
+    ? q.answer
+    : Number.isFinite(q.answer)
+    ? [q.answer]
+    : [];
+  return Array.from(
+    new Set(
+      arr
+        .map((n) => {
+          const num = Number(n);
+          return Number.isFinite(num) ? num : null;
+        })
+        .filter((n) => n !== null),
+    ),
+  ).sort((a, b) => a - b);
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const obj = {};
+    for (const [key, val] of entries) {
+      obj[key] = canonicalize(val);
+    }
+    return obj;
+  }
+  if (typeof value === 'number') return Number.isFinite(value) ? Number(value) : value;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value;
+  if (value === null) return null;
+  return value;
+}
+
+function buildQuestionIdentity(q) {
+  const base = {};
+  for (const [key, value] of Object.entries(q)) {
+    if (OMIT_KEYS.has(key) || key === 'answer' || key === 'answers') continue;
+    if (value === undefined) continue;
+    base[key] = value;
+  }
+  const answers = normalizeAnswers(q);
+  if (answers.length) base.answers = answers;
+  return canonicalize(base);
+}
+
+function questionKey(q) {
+  return JSON.stringify(buildQuestionIdentity(q));
+}
+
 export function syncLocalStorage(defaultSets, allQuestions, storage, questionsKey = 'questions', setsKey = 'sets') {
   let existingQuestions = [];
   try {
@@ -5,22 +64,26 @@ export function syncLocalStorage(defaultSets, allQuestions, storage, questionsKe
   } catch {
     existingQuestions = [];
   }
+
   const qMap = new Map();
-  // Seed map with any previously stored questions, deduping by content and
-  // ignoring ids which may collide across bundled sets.
+
   for (const q of existingQuestions) {
-    const { id: _id, set: _set, ...rest } = q;
-    const key = JSON.stringify(rest);
+    const key = questionKey(q);
     if (!qMap.has(key)) qMap.set(key, q);
   }
-  // Merge in bundled questions using the same content-based key.
+
   for (const q of allQuestions) {
-    const { id: _id, set: _set, ...rest } = q;
-    const key = JSON.stringify(rest);
-    if (!qMap.has(key)) qMap.set(key, q);
+    const key = questionKey(q);
+    if (!qMap.has(key)) {
+      qMap.set(key, q);
+    }
   }
+
+  const mergedQuestions = [...qMap.values()];
+  const validIds = new Set(mergedQuestions.map((q) => q.id));
+
   try {
-    storage.setItem(questionsKey, JSON.stringify([...qMap.values()]));
+    storage.setItem(questionsKey, JSON.stringify(mergedQuestions));
   } catch {
     /* ignore write errors */
   }
@@ -31,25 +94,54 @@ export function syncLocalStorage(defaultSets, allQuestions, storage, questionsKe
   } catch {
     existingSets = [];
   }
-  const sMap = new Map(existingSets.map((s) => [s.id, s]));
+
+  const sMap = new Map(
+    existingSets.map((s) => [
+      s.id,
+      {
+        ...s,
+        questionIds: Array.isArray(s.questionIds) ? [...s.questionIds] : [],
+      },
+    ]),
+  );
+
+  const identityToId = new Map();
+  for (const q of mergedQuestions) {
+    identityToId.set(questionKey(q), q.id);
+  }
+
   for (const [name, arr] of Object.entries(defaultSets)) {
+    const canonicalIds = arr
+      .map((q) => identityToId.get(questionKey(q)))
+      .filter((id) => id !== undefined);
+
     if (!sMap.has(name)) {
       sMap.set(name, {
         id: name,
         name,
-        questionIds: arr.map((q) => q.id),
+        questionIds: canonicalIds,
       });
     } else {
       const existing = sMap.get(name);
-      const ids = new Set(existing.questionIds);
-      for (const q of arr) {
-        ids.add(q.id);
+      const baseIds = Array.isArray(existing.questionIds)
+        ? existing.questionIds.filter((id) => validIds.has(id))
+        : [];
+      const nextIds = [...baseIds];
+      for (const id of canonicalIds) {
+        if (!nextIds.includes(id)) nextIds.push(id);
       }
-      existing.questionIds = Array.from(ids);
+      existing.questionIds = nextIds;
+      if (!existing.name) existing.name = name;
     }
   }
+
+  const sanitizedSets = [...sMap.values()].map((set) => ({
+    ...set,
+    questionIds: (set.questionIds || []).filter((id) => validIds.has(id)),
+  }));
+
   try {
-    storage.setItem(setsKey, JSON.stringify([...sMap.values()]));
+    storage.setItem(setsKey, JSON.stringify(sanitizedSets));
   } catch {
     /* ignore write errors */
   }

--- a/mcqproject/test/storage.test.js
+++ b/mcqproject/test/storage.test.js
@@ -72,3 +72,58 @@ test('adds new sets and questions without duplication', () => {
   const savedQuestions = JSON.parse(storage.getItem('q'));
   assert.strictEqual(savedQuestions.length, allQuestions.length);
 });
+
+test('keeps default set membership stable across repeated syncs', () => {
+  const storage = createMockStorage();
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+  const firstQuestions = JSON.parse(storage.getItem('q'));
+  const firstSets = JSON.parse(storage.getItem('s'));
+
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+
+  const secondQuestions = JSON.parse(storage.getItem('q'));
+  const secondSets = JSON.parse(storage.getItem('s'));
+
+  assert.strictEqual(secondQuestions.length, firstQuestions.length);
+  firstSets.forEach((set) => {
+    const next = secondSets.find((s) => s.id === set.id);
+    assert.ok(next, `missing set ${set.id}`);
+    const expected = [...(set.questionIds || [])].sort();
+    const actual = [...(next.questionIds || [])].sort();
+    assert.deepStrictEqual(actual, expected);
+  });
+});
+
+test('treats redundant answers array as the same question', () => {
+  const storage = createMockStorage();
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+
+  const baselineQuestions = JSON.parse(storage.getItem('q'));
+  const baselineSets = JSON.parse(storage.getItem('s'));
+  const baselineCounts = Object.fromEntries(
+    baselineSets.map((s) => [s.id, (s.questionIds || []).length]),
+  );
+
+  const modified = baselineQuestions.map((q) => ({
+    ...q,
+    answers: Array.isArray(q.answers)
+      ? q.answers
+      : Array.isArray(q.answer)
+      ? q.answer
+      : [q.answer],
+  }));
+  storage.setItem('q', JSON.stringify(modified));
+
+  syncLocalStorage(defaultSets, allQuestions, storage, 'q', 's');
+
+  const nextQuestions = JSON.parse(storage.getItem('q'));
+  const nextSets = JSON.parse(storage.getItem('s'));
+
+  assert.strictEqual(nextQuestions.length, baselineQuestions.length);
+  nextSets.forEach((set) => {
+    const expected = baselineCounts[set.id];
+    if (expected !== undefined) {
+      assert.strictEqual((set.questionIds || []).length, expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- normalize bundled question identities when syncing localStorage so repeated loads reuse the original IDs
- ensure default sets are rewritten with the deduplicated question IDs and prune stale entries
- extend storage sync tests to cover repeated runs and questions that include an answers array

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c82fe8c3c8832cbace87c6990dae15